### PR TITLE
Stage 1: Stripe CLI + Hono skeleton + seed script (with audit fixes)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,16 @@
+# Stripe test-mode keys (from https://dashboard.stripe.com/test/apikeys)
 STRIPE_SECRET_KEY=sk_test_xxx
-STRIPE_PUBLISHABLE_KEY=pk_test_xxx
-STRIPE_WEBHOOK_SECRET=whsec_xxx
-
 VITE_STRIPE_PUBLISHABLE_KEY=pk_test_xxx
+
+# Set at Stage 3 kickoff from `stripe listen --forward-to ...` output.
+# STRIPE_WEBHOOK_SECRET=whsec_xxx
+
+# Frontend (Stage 2+)
 VITE_API_BASE_URL=http://localhost:8787
 
+# Ports
 API_PORT=8787
 WEB_PORT=5173
 
-DATABASE_URL=./stripe-prototype.db
+# SQLite (Stage 3). Path is resolved relative to repo root.
+DATABASE_URL=apps/api/.data/stripe-prototype.db

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Full design and stage plan: [docs/plans/2026-04-24-stripe-prototype-track-a-desi
 
 ## Status
 
-Scaffold stage (Stage 0). No code yet — see design doc for the staged rollout.
+Stage 1 — Stripe CLI + seed script. Bun workspace, Hono API skeleton with `/health` probing `stripe.balance.retrieve()`, and `scripts/seed.ts` creating Customer/Product/Prices in test mode.
 
 ## Stack
 
@@ -17,13 +17,25 @@ Scaffold stage (Stage 0). No code yet — see design doc for the staged rollout.
 - **Shared types:** Zod via `packages/shared`
 - **Payments:** `stripe` SDK, Stripe CLI for local webhook forwarding
 
-## Quickstart (after Stage 1)
+## Quickstart
 
 ```bash
 bun install
-cp .env.example .env   # fill in test keys
-bun run dev            # web + api + stripe listen
+cp .env.example .env   # fill in STRIPE_SECRET_KEY + VITE_STRIPE_PUBLISHABLE_KEY (test mode)
+
+# one-time Stripe CLI login (opens a browser)
+stripe login
+
+# seed practice objects (Customer + Product + Prices)
+bun run seed
+bun run seed -- --cleanup   # same + delete at the end
+
+# start the api (Hono on Bun)
+bun run dev
+curl http://localhost:8787/health   # should return {ok:true, mode:"test"}
 ```
+
+Stage 2 adds the web app; Stage 3 adds `stripe listen` to the dev script.
 
 ## Layout
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,10 +7,13 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
-    "@stripe-prototype/shared": "workspace:*"
+    "@stripe-prototype/shared": "workspace:*",
+    "hono": "^4.12.14",
+    "stripe": "^22.1.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "bun-types": "latest",
+    "bun-types": "1.2.8",
     "typescript": "^5.5.4"
   }
 }

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+const EnvSchema = z.object({
+  STRIPE_SECRET_KEY: z.string().regex(/^sk_(test|live)_/, {
+    message: "STRIPE_SECRET_KEY must start with sk_test_ or sk_live_",
+  }),
+  STRIPE_WEBHOOK_SECRET: z
+    .string()
+    .regex(/^whsec_/, { message: "STRIPE_WEBHOOK_SECRET must start with whsec_" })
+    .optional(),
+  API_PORT: z.coerce.number().int().positive().default(8787),
+  DATABASE_URL: z.string().default("apps/api/.data/stripe-prototype.db"),
+});
+
+export type Env = z.infer<typeof EnvSchema>;
+
+export function loadEnv(): Env {
+  const parsed = EnvSchema.safeParse(Bun.env);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  - ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Invalid environment:\n${issues}`);
+  }
+  return parsed.data;
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,12 +1,19 @@
 import { z } from "zod";
 
+// Stage 1/2 policy: test-mode only. Live keys are rejected at startup so an
+// accidental `.env` swap can't ship test-shaped code against real customers.
+// Bun reads .env in this precedence: .env < .env.{NODE_ENV} < .env.local, and
+// both dotenv files lose to shell/CI-supplied environment variables.
 const EnvSchema = z.object({
-  STRIPE_SECRET_KEY: z.string().regex(/^sk_(test|live)_/, {
-    message: "STRIPE_SECRET_KEY must start with sk_test_ or sk_live_",
+  STRIPE_SECRET_KEY: z.string().regex(/^sk_test_/, {
+    message:
+      "STRIPE_SECRET_KEY must start with sk_test_ (live keys are rejected in this prototype)",
   }),
   STRIPE_WEBHOOK_SECRET: z
     .string()
-    .regex(/^whsec_/, { message: "STRIPE_WEBHOOK_SECRET must start with whsec_" })
+    .regex(/^whsec_/, {
+      message: "STRIPE_WEBHOOK_SECRET must start with whsec_",
+    })
     .optional(),
   API_PORT: z.coerce.number().int().positive().default(8787),
   DATABASE_URL: z.string().default("apps/api/.data/stripe-prototype.db"),
@@ -14,12 +21,15 @@ const EnvSchema = z.object({
 
 export type Env = z.infer<typeof EnvSchema>;
 
+function formatIssue(i: z.core.$ZodIssue): string {
+  // Never echo the offending input back — a bad SECRET_KEY would leak to stderr.
+  return `  - ${i.path.join(".") || "(env)"}: ${i.message}`;
+}
+
 export function loadEnv(): Env {
   const parsed = EnvSchema.safeParse(Bun.env);
   if (!parsed.success) {
-    const issues = parsed.error.issues
-      .map((i) => `  - ${i.path.join(".")}: ${i.message}`)
-      .join("\n");
+    const issues = parsed.error.issues.map(formatIssue).join("\n");
     throw new Error(`Invalid environment:\n${issues}`);
   }
   return parsed.data;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,27 +1,41 @@
+import Stripe from "stripe";
 import { Hono } from "hono";
 import { loadEnv } from "./env";
-import { makeStripe } from "./stripe";
+import { makeStripe, STRIPE_API_VERSION } from "./stripe";
 
 const env = loadEnv();
 const stripe = makeStripe(env.STRIPE_SECRET_KEY);
 
 const app = new Hono();
 
-app.get("/", (c) => c.json({ ok: true, stage: 1 }));
+app.get("/", (c) =>
+  c.json({ ok: true, stage: 1, api_version: STRIPE_API_VERSION }),
+);
 
 app.get("/health", async (c) => {
+  c.header("Cache-Control", "no-store");
   try {
     // Balance.retrieve() is the lightest "is the key valid + account reachable" call.
     await stripe.balance.retrieve();
-    return c.json({
-      ok: true,
-      mode: env.STRIPE_SECRET_KEY.startsWith("sk_test_") ? "test" : "live",
-    });
+    return c.json({ ok: true, mode: "test", api_version: STRIPE_API_VERSION });
   } catch (err) {
-    return c.json(
-      { ok: false, error: err instanceof Error ? err.message : String(err) },
-      500,
-    );
+    // Never surface err.message: Stripe errors can include the last 4 of the
+    // key or a request URL. Shape the response to type/code/requestId only.
+    if (err instanceof Stripe.errors.StripeError) {
+      const status = err instanceof Stripe.errors.StripeConnectionError ? 503 : 500;
+      return c.json(
+        {
+          ok: false,
+          error: {
+            type: err.type,
+            code: err.code ?? null,
+            requestId: err.requestId ?? null,
+          },
+        },
+        status,
+      );
+    }
+    return c.json({ ok: false, error: { type: "unknown" } }, 500);
   }
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,1 +1,31 @@
-export {};
+import { Hono } from "hono";
+import { loadEnv } from "./env";
+import { makeStripe } from "./stripe";
+
+const env = loadEnv();
+const stripe = makeStripe(env.STRIPE_SECRET_KEY);
+
+const app = new Hono();
+
+app.get("/", (c) => c.json({ ok: true, stage: 1 }));
+
+app.get("/health", async (c) => {
+  try {
+    // Balance.retrieve() is the lightest "is the key valid + account reachable" call.
+    await stripe.balance.retrieve();
+    return c.json({
+      ok: true,
+      mode: env.STRIPE_SECRET_KEY.startsWith("sk_test_") ? "test" : "live",
+    });
+  } catch (err) {
+    return c.json(
+      { ok: false, error: err instanceof Error ? err.message : String(err) },
+      500,
+    );
+  }
+});
+
+export default {
+  port: env.API_PORT,
+  fetch: app.fetch,
+};

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1,7 +1,13 @@
 import Stripe from "stripe";
 
+// Pin the wire-level API version so `stripe` npm bumps or dashboard-default
+// migrations don't silently change behavior in Stage 2+. Matches the default
+// shipped with `stripe@22.1.0` at the time of pin (2026-04-24).
+export const STRIPE_API_VERSION = "2026-04-22.dahlia" as const;
+
 export function makeStripe(secretKey: string): Stripe {
   return new Stripe(secretKey, {
+    apiVersion: STRIPE_API_VERSION,
     typescript: true,
   });
 }

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1,0 +1,7 @@
+import Stripe from "stripe";
+
+export function makeStripe(secretKey: string): Stripe {
+  return new Stripe(secretKey, {
+    typescript: true,
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "stripe-prototype",
       "devDependencies": {
+        "concurrently": "^9.2.1",
         "typescript": "^5.5.4",
       },
     },
@@ -11,9 +12,12 @@
       "name": "api",
       "dependencies": {
         "@stripe-prototype/shared": "workspace:*",
+        "hono": "^4.12.14",
+        "stripe": "^22.1.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "1.2.8",
         "typescript": "^5.5.4",
       },
     },
@@ -29,6 +33,9 @@
     "packages/shared": {
       "name": "@stripe-prototype/shared",
       "version": "0.0.0",
+      "dependencies": {
+        "zod": "^4.3.6",
+      },
       "devDependencies": {
         "typescript": "^5.5.4",
       },
@@ -39,14 +46,72 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "api": ["api@workspace:apps/api"],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.2.8", "", { "dependencies": { "@types/node": "*", "@types/ws": "*" } }, "sha512-D5npfxKIGuYe9dTHLK1hi4XFmbMdKYoLrgyd25rrUyCrnyU4ljmQW7vDdonvibKeyU72mZuixIhQ2J+q6uM0Mg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "stripe": ["stripe@22.1.0", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw=="],
+
+    "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "web": ["web@workspace:apps/web"],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
   }
 }

--- a/docs/audits/stage-1-audit.md
+++ b/docs/audits/stage-1-audit.md
@@ -1,0 +1,84 @@
+# Stage 1 Audit
+
+**Commit reviewed:** `5825da1` on `stage/1-stripe-cli-seed`
+**Fixes commit:** (this commit — `fix(stage-1): …`)
+**Reviewed:** 2026-04-24
+**Reviewers:** `superpowers:code-reviewer` + `codex:codex-rescue` (parallel, independent)
+**Outcome:** 2 BLOCKER (codex-only), multiple MAJOR (both reviewers converged), several MINOR — all applied on the same branch.
+
+## Consolidated findings
+
+### BLOCKER — fixed
+
+| # | Location | Finding | Fix applied |
+|---|---|---|---|
+| B1 | `scripts/seed.ts` cleanup path | `stripe.products.del()` on a Product that still has attached Prices returns 400 — prices cannot be hard-deleted (only deactivated), and a Product with any Prices cannot be hard-deleted either. The original `destroy()` would have failed end-to-end on the first real cleanup run. | Replaced `products.del` with `products.update({ active: false })` (archive). Prices remain deactivated via `prices.update({ active: false })`. Customer is still hard-deleted. |
+| B2 | `apps/api/src/env.ts` | Stage 1 policy is test-mode-only, but the env schema accepted both `sk_test_` and `sk_live_`. A misplaced `.env` could have the API report `mode: "live"` and the seed script transact live in a future stage that reused `loadEnv`. | Tightened regex to `^sk_test_` only. `STRIPE_SECRET_KEY` starting with `sk_live_` now aborts at startup with a clear error. Escape hatch for live mode (if ever needed later) would be a separate env var, not a relaxed regex. |
+
+### MAJOR — fixed
+
+| # | Location | Finding | Fix applied |
+|---|---|---|---|
+| M1 | `apps/api/src/stripe.ts` + `scripts/seed.ts` | Stripe client constructed without `apiVersion`. Wire-level behavior drifts silently with SDK bumps or account default changes. | Pinned `apiVersion = '2026-04-22.dahlia'` (matches `stripe@22.1.0` default, verified via `node_modules/stripe/esm/apiVersion.js`). Exported `STRIPE_API_VERSION` constant. |
+| M2 | `scripts/seed.ts` | Duplicated env validation (own `Bun.env.STRIPE_SECRET_KEY.startsWith` check) and instantiated a second Stripe client instead of reusing `makeStripe`. Two code paths for one secret is a classic drift bug. | Seed now imports `loadEnv` + `makeStripe` from `apps/api/src`. Single validation surface; single pinned client. The `sk_live_` hard-block from B2 protects seed too. |
+| M3 | `scripts/seed.ts` Search queries | Used `metadata['seed_tag']:'…'` (single quotes). Stripe's Search docs specify double quotes (`metadata["key"]:"value"`). Single-quoted form works on some shards and fails on others — latent bug that a mock wouldn't catch. | Switched to `metadata["seed_tag"]:"${tag}"`. Verified against docs.stripe.com/search. |
+| M4 | `scripts/seed.ts` eventual consistency | 2-second sleep before Search was a magic number; Stripe SDK types themselves warn "searchable in less than a minute, longer during outages." | Replaced with `retry()` helper: 4 attempts, exponential backoff from 750ms. Returns best-effort result; cleanup remains ID-driven regardless of Search success. |
+
+### MINOR — fixed in this commit
+
+| # | Location | Finding | Fix applied |
+|---|---|---|---|
+| m1 | `apps/api/src/index.ts` `/health` | Returned `err.message` which can include last-4 of the key, request URL, request-id, etc. Leaks internals. | Type-branch on `Stripe.errors.StripeError`; respond with `{ type, code, requestId }` only. 503 on connection errors, 500 on others. `Cache-Control: no-store` added. |
+| m2 | `scripts/seed.ts` `destroy()` | Any single failure aborted cleanup; remaining objects leaked. | Each step wrapped in `tryStep()` — logs failure and continues. Cleanup is now best-effort by design. |
+| m3 | `packages/shared/src/index.ts` `IsoCurrencySchema` | `z.string().length(3)` admitted `"123"` / `"us$"`. | Added `/^[A-Za-z]{3}$/` regex before lowercase transform. |
+| m4 | `scripts/seed.ts` CLI ergonomics | Couldn't clean up a previous-run tag (always generated a fresh `seed-${Date.now()}`). | Added `--tag=<value>` flag. `--tag=X` alone lists; `--tag=X --cleanup` discovers via Search then deletes. Unlocks recovery from a failed seed. |
+
+### MINOR — filed as GitHub issues
+
+| # | Scope | Issue |
+|---|---|---|
+| i-stage1-A | Stage 3 prep | Reserve `POST /webhook` route before any global JSON/body-parser middleware lands; webhook needs raw body. |
+| i-stage1-B | Any stage | Sanitized startup config log (mode, port, DB path) + env precedence doc in README. |
+| i-stage1-C | Stage 3 | Resolve `DATABASE_URL` via `import.meta.dir` not `process.cwd()` so CWD shifts don't fork the idempotency DB. |
+
+### NIT — wontfix / note-only
+
+| # | Location | Finding | Disposition |
+|---|---|---|---|
+| n1 | `scripts/seed.ts:1` | Shebang `#!/usr/bin/env bun` but file isn't `chmod +x` and is always run via `bun run`. | Removed shebang; matches actual invocation. |
+| n2 | seed-tag format | `metadata.seed_tag = seed-${Date.now()}` → suggested `seed_${crypto.randomUUID().slice(0,8)}` for dashboard hygiene. | Wontfix — `Date.now()` is human-sortable; dashboard noise is negligible at this scale. |
+| n3 | `.env.example` | `STRIPE_SECRET_KEY` vs `VITE_STRIPE_PUBLISHABLE_KEY` name asymmetry. | Intentional — VITE_ prefix is required for Vite client-bundle exposure. No change. |
+| n4 | `apps/api/src/index.ts:28-31` | `export default { port, fetch }` shape. | Verified correct for `Bun.serve`. |
+
+## Explicitly verified correct (coverage evidence)
+
+Both reviewers independently validated:
+- zod schema shape for Stage-1 env (`STRIPE_SECRET_KEY` required, `STRIPE_WEBHOOK_SECRET` optional-until-Stage-3, `API_PORT` coerced, `DATABASE_URL` defaulted).
+- `Bun.env` (which is `process.env` under the hood) as the right source; precedence is `.env` < `.env.$NODE_ENV` < `.env.local` < shell/CI.
+- `z.coerce.number().int().positive()` on `API_PORT` (coercion needed because env values are strings).
+- `typescript: true` on Stripe client (stricter TS types).
+- Workspace protocol `"@stripe-prototype/shared": "workspace:*"` correct for Bun.
+- `bun-types` pin to `1.2.8` (matches runtime), issue #3 closed.
+- `concurrently -k -n api` in root `dev` (issue #4 closed).
+- Price deactivation (not deletion) ordering: prices → product archive → customer delete.
+- `recurring: { interval }` shape on Price create.
+- `tsconfig.base.json` strict options (`exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`) — the `seed.ts` conditional-spread pattern for `description` is required precisely because of `exactOptionalPropertyTypes`.
+
+## Reviewer disagreement / ambiguity
+
+- **Search query quoting:** code-reviewer flagged single-quote as MAJOR with high confidence; codex flagged as MINOR ("exact syntax unverified from SDK"). Resolved by WebFetch to docs.stripe.com/search which confirms double-quote is canonical. Fix applied (M3).
+- **`sk_live_` at env layer:** code-reviewer flagged as m1 (MINOR "set the wrong precedent"); codex flagged as BLOCKER ("live key would start the API in live mode"). Resolved by adopting codex's stricter reading — Stage 1/2 policy is test-only, so the env schema enforces it. Easy to relax later with explicit opt-in.
+
+## End-to-end verification
+
+- `bun --filter '*' typecheck` exits 0 after all fixes.
+- End-to-end seed against a real `sk_test_` account has NOT been performed in this session (no key available). User is expected to run `bun run seed` with their own test key before closing PR #2. Recovery path exists via `--tag=<value> --cleanup` if the create path partially succeeds.
+
+## Closed issues from Stage 0
+
+- #2 — `.env.example` cleanup ✓
+- #3 — `bun-types` pinned to 1.2.8 ✓
+- #4 — root `dev` script wired ✓
+- #5 — apps/api dev points at a real Hono server ✓
+
+Issue #6 (SQLite path + single-process) remains open — belongs to Stage 3.

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   ],
   "scripts": {
     "typecheck": "bun --filter '*' typecheck",
-    "dev": "echo 'Stage 1+: wired up then'; exit 1"
+    "dev": "concurrently -k -n api -c green \"bun --filter api dev\"",
+    "seed": "bun run scripts/seed.ts"
   },
   "devDependencies": {
+    "concurrently": "^9.2.1",
     "typescript": "^5.5.4"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,5 +13,8 @@
   },
   "devDependencies": {
     "typescript": "^5.5.4"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 export const IsoCurrencySchema = z
   .string()
-  .length(3)
+  .regex(/^[A-Za-z]{3}$/, {
+    message: "currency must be a 3-letter ISO code (e.g. usd, eur)",
+  })
   .transform((s) => s.toLowerCase());
 
 export const SeedProductSchema = z.object({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,25 @@
-export {};
+import { z } from "zod";
+
+export const IsoCurrencySchema = z
+  .string()
+  .length(3)
+  .transform((s) => s.toLowerCase());
+
+export const SeedProductSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+});
+
+export type SeedProduct = z.infer<typeof SeedProductSchema>;
+
+export const SeedOneTimePriceSchema = z.object({
+  unit_amount: z.number().int().positive(),
+  currency: IsoCurrencySchema,
+});
+
+export const SeedRecurringPriceSchema = SeedOneTimePriceSchema.extend({
+  interval: z.enum(["day", "week", "month", "year"]),
+});
+
+export type SeedOneTimePrice = z.infer<typeof SeedOneTimePriceSchema>;
+export type SeedRecurringPrice = z.infer<typeof SeedRecurringPriceSchema>;

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env bun
+/**
+ * Stage 1 seed: hands-on practice with Stripe's core objects.
+ * Creates one Customer, one Product, one one-time Price, one recurring Price,
+ * lists them, and (if `--cleanup`) deletes the objects this run created.
+ *
+ * Usage:
+ *   bun run seed                # create + list
+ *   bun run seed -- --cleanup   # create + list + delete
+ */
+import Stripe from "stripe";
+import {
+  SeedOneTimePriceSchema,
+  SeedProductSchema,
+  SeedRecurringPriceSchema,
+} from "@stripe-prototype/shared";
+
+const secret = Bun.env.STRIPE_SECRET_KEY;
+if (!secret || !secret.startsWith("sk_test_")) {
+  console.error(
+    "STRIPE_SECRET_KEY missing or not a test key (must start with sk_test_).",
+  );
+  process.exit(1);
+}
+
+const stripe = new Stripe(secret, { typescript: true });
+const cleanup = process.argv.includes("--cleanup");
+const tag = `seed-${Date.now()}`;
+
+type Created = {
+  customer: Stripe.Customer;
+  product: Stripe.Product;
+  oneTimePrice: Stripe.Price;
+  recurringPrice: Stripe.Price;
+};
+
+async function create(): Promise<Created> {
+  const product = SeedProductSchema.parse({
+    name: `Prototype Widget (${tag})`,
+    description: "Stage 1 seed object — safe to delete.",
+  });
+  const oneTime = SeedOneTimePriceSchema.parse({
+    unit_amount: 1999,
+    currency: "usd",
+  });
+  const recurring = SeedRecurringPriceSchema.parse({
+    unit_amount: 999,
+    currency: "usd",
+    interval: "month",
+  });
+
+  const customer = await stripe.customers.create({
+    email: `${tag}@example.com`,
+    name: `Seed Customer ${tag}`,
+    metadata: { seed_tag: tag },
+  });
+  console.log(`✓ customer  ${customer.id} (${customer.email})`);
+
+  const createdProduct = await stripe.products.create({
+    name: product.name,
+    ...(product.description !== undefined
+      ? { description: product.description }
+      : {}),
+    metadata: { seed_tag: tag },
+  });
+  console.log(`✓ product   ${createdProduct.id} (${createdProduct.name})`);
+
+  const oneTimePrice = await stripe.prices.create({
+    product: createdProduct.id,
+    unit_amount: oneTime.unit_amount,
+    currency: oneTime.currency,
+    metadata: { seed_tag: tag, kind: "one_time" },
+  });
+  console.log(
+    `✓ price     ${oneTimePrice.id} (one-time, ${oneTime.unit_amount} ${oneTime.currency})`,
+  );
+
+  const recurringPrice = await stripe.prices.create({
+    product: createdProduct.id,
+    unit_amount: recurring.unit_amount,
+    currency: recurring.currency,
+    recurring: { interval: recurring.interval },
+    metadata: { seed_tag: tag, kind: "recurring" },
+  });
+  console.log(
+    `✓ price     ${recurringPrice.id} (recurring ${recurring.interval}, ${recurring.unit_amount} ${recurring.currency})`,
+  );
+
+  return { customer, product: createdProduct, oneTimePrice, recurringPrice };
+}
+
+async function list(tag: string): Promise<void> {
+  console.log(`\n--- listing objects tagged ${tag} ---`);
+  const customers = await stripe.customers.search({
+    query: `metadata['seed_tag']:'${tag}'`,
+  });
+  for (const c of customers.data) {
+    console.log(`  customer ${c.id} ${c.email ?? ""}`);
+  }
+  const products = await stripe.products.search({
+    query: `metadata['seed_tag']:'${tag}'`,
+  });
+  for (const p of products.data) {
+    console.log(`  product  ${p.id} ${p.name}`);
+  }
+  const prices = await stripe.prices.search({
+    query: `metadata['seed_tag']:'${tag}'`,
+  });
+  for (const p of prices.data) {
+    console.log(
+      `  price    ${p.id} ${p.recurring ? `recurring/${p.recurring.interval}` : "one-time"} ${p.unit_amount} ${p.currency}`,
+    );
+  }
+}
+
+async function destroy(created: Created): Promise<void> {
+  console.log(`\n--- cleaning up ${tag} ---`);
+  // Prices cannot be deleted, only deactivated.
+  await stripe.prices.update(created.oneTimePrice.id, { active: false });
+  console.log(`✓ price      ${created.oneTimePrice.id} deactivated`);
+  await stripe.prices.update(created.recurringPrice.id, { active: false });
+  console.log(`✓ price      ${created.recurringPrice.id} deactivated`);
+  await stripe.products.del(created.product.id);
+  console.log(`✓ product    ${created.product.id} deleted`);
+  await stripe.customers.del(created.customer.id);
+  console.log(`✓ customer   ${created.customer.id} deleted`);
+}
+
+const created = await create();
+
+// Stripe search is eventually consistent — wait before listing, or the newly
+// created objects may not appear in results.
+await new Promise((r) => setTimeout(r, 2000));
+await list(tag);
+
+if (cleanup) {
+  await destroy(created);
+}
+
+console.log("\nDone.");

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,37 +1,68 @@
-#!/usr/bin/env bun
 /**
  * Stage 1 seed: hands-on practice with Stripe's core objects.
- * Creates one Customer, one Product, one one-time Price, one recurring Price,
- * lists them, and (if `--cleanup`) deletes the objects this run created.
  *
- * Usage:
- *   bun run seed                # create + list
- *   bun run seed -- --cleanup   # create + list + delete
+ * Creates one Customer, one Product, one one-time Price, and one recurring
+ * Price (all tagged `metadata.seed_tag`). Lists them via Stripe Search (with
+ * bounded retry for eventual-consistency). Optionally cleans them up.
+ *
+ * Usage (root scripts pass args through `bun run seed -- ...`):
+ *   bun run seed                         # create + list
+ *   bun run seed -- --cleanup            # create + list + archive/delete
+ *   bun run seed -- --tag=seed-1700... --cleanup  # clean up a prior run only
  */
-import Stripe from "stripe";
 import {
   SeedOneTimePriceSchema,
   SeedProductSchema,
   SeedRecurringPriceSchema,
 } from "@stripe-prototype/shared";
+import { loadEnv } from "../apps/api/src/env";
+import { makeStripe } from "../apps/api/src/stripe";
 
-const secret = Bun.env.STRIPE_SECRET_KEY;
-if (!secret || !secret.startsWith("sk_test_")) {
-  console.error(
-    "STRIPE_SECRET_KEY missing or not a test key (must start with sk_test_).",
-  );
-  process.exit(1);
+type Args = {
+  cleanup: boolean;
+  tag: string | null;
+};
+
+function parseArgs(argv: readonly string[]): Args {
+  let cleanup = false;
+  let tag: string | null = null;
+  for (const a of argv) {
+    if (a === "--cleanup") cleanup = true;
+    else if (a.startsWith("--tag=")) tag = a.slice("--tag=".length);
+  }
+  return { cleanup, tag };
 }
 
-const stripe = new Stripe(secret, { typescript: true });
-const cleanup = process.argv.includes("--cleanup");
-const tag = `seed-${Date.now()}`;
+async function retry<T>(
+  op: () => Promise<T>,
+  predicate: (result: T) => boolean,
+  opts: { attempts: number; baseMs: number; label: string },
+): Promise<T> {
+  let last!: T;
+  for (let i = 0; i < opts.attempts; i++) {
+    last = await op();
+    if (predicate(last)) return last;
+    if (i < opts.attempts - 1) {
+      const waitMs = opts.baseMs * Math.pow(2, i);
+      console.log(
+        `  ... ${opts.label} not ready after attempt ${i + 1}, retrying in ${waitMs}ms`,
+      );
+      await new Promise((r) => setTimeout(r, waitMs));
+    }
+  }
+  return last;
+}
+
+const env = loadEnv();
+const stripe = makeStripe(env.STRIPE_SECRET_KEY);
+const args = parseArgs(process.argv.slice(2));
+const tag = args.tag ?? `seed-${Date.now()}`;
 
 type Created = {
-  customer: Stripe.Customer;
-  product: Stripe.Product;
-  oneTimePrice: Stripe.Price;
-  recurringPrice: Stripe.Price;
+  customerId: string;
+  productId: string;
+  oneTimePriceId: string;
+  recurringPriceId: string;
 };
 
 async function create(): Promise<Created> {
@@ -86,55 +117,115 @@ async function create(): Promise<Created> {
     `✓ price     ${recurringPrice.id} (recurring ${recurring.interval}, ${recurring.unit_amount} ${recurring.currency})`,
   );
 
-  return { customer, product: createdProduct, oneTimePrice, recurringPrice };
+  return {
+    customerId: customer.id,
+    productId: createdProduct.id,
+    oneTimePriceId: oneTimePrice.id,
+    recurringPriceId: recurringPrice.id,
+  };
 }
 
-async function list(tag: string): Promise<void> {
-  console.log(`\n--- listing objects tagged ${tag} ---`);
-  const customers = await stripe.customers.search({
-    query: `metadata['seed_tag']:'${tag}'`,
-  });
+async function list(tag: string): Promise<Created | null> {
+  console.log(`\n--- listing objects tagged ${tag} (via Search, best-effort) ---`);
+  // Stripe's docs use double-quoted metadata query values; single quotes work
+  // on some shards and fail on others. Official syntax is `metadata["key"]:"value"`.
+  const query = `metadata["seed_tag"]:"${tag}"`;
+
+  // Search is eventually consistent — "searchable in less than a minute" per SDK
+  // notes. Retry with exponential backoff instead of a magic sleep.
+  const customers = await retry(
+    () => stripe.customers.search({ query }),
+    (r) => r.data.length > 0,
+    { attempts: 4, baseMs: 750, label: "customer search" },
+  );
+  const products = await retry(
+    () => stripe.products.search({ query }),
+    (r) => r.data.length > 0,
+    { attempts: 4, baseMs: 750, label: "product search" },
+  );
+  const prices = await retry(
+    () => stripe.prices.search({ query }),
+    (r) => r.data.length >= 2,
+    { attempts: 4, baseMs: 750, label: "price search" },
+  );
+
   for (const c of customers.data) {
     console.log(`  customer ${c.id} ${c.email ?? ""}`);
   }
-  const products = await stripe.products.search({
-    query: `metadata['seed_tag']:'${tag}'`,
-  });
   for (const p of products.data) {
     console.log(`  product  ${p.id} ${p.name}`);
   }
-  const prices = await stripe.prices.search({
-    query: `metadata['seed_tag']:'${tag}'`,
-  });
   for (const p of prices.data) {
     console.log(
       `  price    ${p.id} ${p.recurring ? `recurring/${p.recurring.interval}` : "one-time"} ${p.unit_amount} ${p.currency}`,
     );
   }
+
+  if (!customers.data[0] || !products.data[0] || prices.data.length === 0) {
+    console.log(
+      "  (search may still be indexing; cleanup below uses direct IDs, not search)",
+    );
+    return null;
+  }
+  return {
+    customerId: customers.data[0].id,
+    productId: products.data[0].id,
+    oneTimePriceId:
+      prices.data.find((p) => !p.recurring)?.id ?? prices.data[0]!.id,
+    recurringPriceId:
+      prices.data.find((p) => p.recurring)?.id ?? prices.data[0]!.id,
+  };
 }
 
 async function destroy(created: Created): Promise<void> {
-  console.log(`\n--- cleaning up ${tag} ---`);
-  // Prices cannot be deleted, only deactivated.
-  await stripe.prices.update(created.oneTimePrice.id, { active: false });
-  console.log(`✓ price      ${created.oneTimePrice.id} deactivated`);
-  await stripe.prices.update(created.recurringPrice.id, { active: false });
-  console.log(`✓ price      ${created.recurringPrice.id} deactivated`);
-  await stripe.products.del(created.product.id);
-  console.log(`✓ product    ${created.product.id} deleted`);
-  await stripe.customers.del(created.customer.id);
-  console.log(`✓ customer   ${created.customer.id} deleted`);
+  console.log(`\n--- cleaning up ${tag} (best-effort) ---`);
+
+  const tryStep = async (label: string, fn: () => Promise<unknown>) => {
+    try {
+      await fn();
+      console.log(`  ✓ ${label}`);
+    } catch (err) {
+      console.log(
+        `  ✗ ${label} — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+
+  // Prices cannot be hard-deleted, only deactivated.
+  await tryStep(`deactivate price ${created.oneTimePriceId}`, () =>
+    stripe.prices.update(created.oneTimePriceId, { active: false }),
+  );
+  await tryStep(`deactivate price ${created.recurringPriceId}`, () =>
+    stripe.prices.update(created.recurringPriceId, { active: false }),
+  );
+  // Products with any attached Prices cannot be hard-deleted either — archive
+  // them (active: false) instead. `products.del` would return a 400.
+  await tryStep(`archive product ${created.productId}`, () =>
+    stripe.products.update(created.productId, { active: false }),
+  );
+  await tryStep(`delete customer ${created.customerId}`, () =>
+    stripe.customers.del(created.customerId),
+  );
 }
 
-const created = await create();
-
-// Stripe search is eventually consistent — wait before listing, or the newly
-// created objects may not appear in results.
-await new Promise((r) => setTimeout(r, 2000));
-await list(tag);
-
-if (cleanup) {
-  await destroy(created);
+if (args.tag && !args.cleanup) {
+  // --tag without --cleanup: just list what's under that tag.
+  await list(args.tag);
+} else if (args.tag && args.cleanup) {
+  // --tag with --cleanup: discover by search, clean up. Handles prior runs.
+  const discovered = await list(args.tag);
+  if (discovered) {
+    await destroy(discovered);
+  } else {
+    console.log("  nothing to clean up under that tag");
+  }
+} else {
+  // No --tag: normal "create + list + optional cleanup" flow.
+  const created = await create();
+  await list(tag);
+  if (args.cleanup) {
+    await destroy(created);
+  }
 }
 
 console.log("\nDone.");


### PR DESCRIPTION
## Summary

Stage 1 of the [Track A plan](./docs/plans/2026-04-24-stripe-prototype-track-a-design.md). Stripe CLI installed (1.40.7), Hono API skeleton with `/health`, and `scripts/seed.ts` creating Customer / Product / one-time Price / recurring Price in test mode.

### Implementation commit (`5825da1`)
- `apps/api/src/{env,stripe,index}.ts` — zod env loader, pinned Stripe client factory, Hono server
- `packages/shared/src/index.ts` — zod schemas for seed objects
- `scripts/seed.ts` — the seed script with list + optional cleanup
- `.env.example` cleaned per issue #2, `bun-types` pinned per issue #3, `dev` scripts wired per issues #4 and #5

### Audit fixes commit (`4ec9e8f`)
Dual review (`superpowers:code-reviewer` + `codex:codex-rescue`) surfaced **2 BLOCKERs** + several MAJORs + MINORs — all applied. Full punch list in [`docs/audits/stage-1-audit.md`](./docs/audits/stage-1-audit.md).

**BLOCKER fixes:**
- `products.del()` on a Product with attached Prices returns 400 → switched to archive (`products.update({active:false})`)
- env accepted `sk_live_` → tightened to `^sk_test_` only for Stage 1/2 test-mode policy

**MAJOR fixes:**
- Pinned `apiVersion = '2026-04-22.dahlia'`; seed script imports `makeStripe()` instead of instantiating a second client
- Stripe Search metadata queries switched from single-quotes to double-quotes per official syntax
- 2s sleep before Search replaced with bounded exponential-backoff retry
- Single validation surface for `STRIPE_SECRET_KEY` (seed reuses `loadEnv`)

**MINOR fixes:**
- `/health` no longer leaks Stripe error internals (`{type,code,requestId}` only; 503 on connection errors; `Cache-Control: no-store`)
- `destroy()` is best-effort (each step in `tryStep`)
- `IsoCurrencySchema` tightened to `/^[A-Za-z]{3}$/`
- `--tag=<value>` flag for cleaning up a prior-run's tag

## MINOR deferrals filed as issues
- A (Stage 3) — reserve `POST /webhook` before any global body parser lands
- B (any stage) — sanitized startup config log + env precedence doc
- C (Stage 3) — resolve DB path via `import.meta.dir` not `process.cwd()`

## Closes Stage 0 issues
- Closes #2, #3, #4, #5 (issue #6 belongs to Stage 3)

## Test plan
- [x] `bun --filter '*' typecheck` exit 0 across all workspaces
- [x] Env-missing error path fires before any Stripe call (`STRIPE_SECRET_KEY="" bun run scripts/seed.ts` → clean zod error)
- [ ] End-to-end: fill `.env` with a real `sk_test_`, run `bun run seed`, verify dashboard shows 1 Customer + 1 Product + 2 Prices tagged `seed_tag`
- [ ] `bun run seed -- --cleanup` → dashboard empty; prices deactivated (not deleted), product archived, customer deleted
- [ ] `bun run seed -- --tag=<existing> --cleanup` → recovers orphaned objects from a failed prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)