### PR TITLE
fix(stage-3): dual-review audit (raw-body cache, filter-first idempotency, requires_action, enum closure)

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdir } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
+import type { OrderStatus } from "@stripe-prototype/shared";
 
 // Resolve relative DATABASE_URL from the apps/api package root, not the
 // caller's CWD. One-place fix for stage-0/#6 and stage-1/#10 — running
@@ -31,9 +32,14 @@ export type Db = {
   getOrder(orderId: string): OrderRow | null;
   getOrderByIntent(paymentIntentId: string): OrderRow | null;
   insertOrder(
-    row: Omit<OrderRow, "created_at" | "updated_at">,
+    row: Omit<OrderRow, "created_at" | "updated_at" | "status"> & {
+      status: OrderStatus;
+    },
   ): void;
-  updateOrderStatus(orderId: string, status: string): void;
+  // OrderStatus-typed so callers can't smuggle in an unknown string; the
+  // shared enum is the canonical contract and the GET /order route will
+  // 500 on anything outside it.
+  updateOrderStatus(orderId: string, status: OrderStatus): void;
   // Webhook idempotency: returns true iff this event.id was newly recorded.
   // A false return means Stripe is re-delivering — skip the handler body.
   markEventProcessed(eventId: string, eventType: string): boolean;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -35,7 +35,7 @@ if (env.STRIPE_WEBHOOK_SECRET) {
 }
 
 app.get("/", (c) =>
-  c.json({ ok: true, stage: 1, api_version: STRIPE_API_VERSION }),
+  c.json({ ok: true, stage: 3, api_version: STRIPE_API_VERSION }),
 );
 
 app.get("/health", async (c) => {

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -5,10 +5,17 @@ import type { Db } from "../db";
 // Maps Stripe event -> next order status. Any event not listed is ignored
 // (with a 200 so Stripe doesn't retry). Charge refunds carry the intent id,
 // not the order id, so the handler looks up the order via getOrderByIntent.
+//
+// `payment_intent.requires_action` IS handled — it's the 3DS/authenticating
+// transition surface. Omitting it would leave the DB status stuck at
+// `processing` while the user is being challenged, and the success-page poll
+// would show stale state. The shared OrderStatusSchema already has a slot
+// for "requires_action"; this wires the webhook end of that contract.
 type HandledEvent =
   | "payment_intent.succeeded"
   | "payment_intent.payment_failed"
   | "payment_intent.processing"
+  | "payment_intent.requires_action"
   | "payment_intent.canceled"
   | "charge.refunded";
 
@@ -16,6 +23,7 @@ const HANDLED_EVENTS: ReadonlySet<string> = new Set<HandledEvent>([
   "payment_intent.succeeded",
   "payment_intent.payment_failed",
   "payment_intent.processing",
+  "payment_intent.requires_action",
   "payment_intent.canceled",
   "charge.refunded",
 ]);
@@ -28,10 +36,13 @@ export function webhookRoutes(deps: {
   const app = new Hono();
 
   app.post("/stripe", async (c) => {
-    // Signature verify MUST run on the unparsed byte stream Stripe signed.
-    // c.req.raw is the underlying Fetch Request — .text() reads the body
-    // exactly once without JSON-parsing first. Hono's c.req.json() would
-    // consume and re-serialize, which changes the bytes and fails the HMAC.
+    // Signature verify MUST run on the body bytes Stripe signed. We use
+    // `c.req.text()` (Hono's cached reader) rather than `c.req.raw.text()`:
+    // Hono's own error message explicitly warns against consuming
+    // `c.req.raw` directly, and the cached path is robust to another
+    // middleware having touched the body via Hono helpers first. JSON
+    // re-serialization (c.req.json()) would still fail the HMAC — text-mode
+    // preserves the bytes.
     const sig = c.req.header("stripe-signature");
     if (!sig) {
       return c.json(
@@ -39,17 +50,18 @@ export function webhookRoutes(deps: {
         400,
       );
     }
-    const rawBody = await c.req.raw.text();
+    const rawBody = await c.req.text();
 
     let event: Stripe.Event;
     try {
-      // constructEventAsync uses Web Crypto (SubtleCrypto), which Bun supports
-      // natively. The sync variant requires Node's crypto module and would
-      // fail under Bun's default runtime.
+      // constructEventAsync uses Web Crypto (SubtleCrypto), preferred for
+      // Web-Crypto-style runtimes including Bun. Default tolerance is 300s;
+      // passed explicitly here for readability of the retry window.
       event = await deps.stripe.webhooks.constructEventAsync(
         rawBody,
         sig,
         deps.webhookSecret,
+        300,
       );
     } catch (err) {
       // Never echo err.message: signature errors can include timing details
@@ -61,18 +73,22 @@ export function webhookRoutes(deps: {
       return c.json({ ok: false, error: { type: code } }, 400);
     }
 
-    // Idempotency gate: Stripe retries on any non-2xx and can also re-deliver
-    // on network blips even after a 2xx. Events the CLI `stripe events resend`
-    // also land here. If we've seen this id, acknowledge without side effects.
+    // Filter-first: only record events we actually dispatch. Recording
+    // unknown types would burn their event.id, and a later stage that adds
+    // a handler for that type could never backfill via `stripe events
+    // resend` — the idempotency gate would silently skip the replay. So
+    // ignored events return 200 with NO side effects (Stripe still stops
+    // retrying because 2xx).
+    if (!HANDLED_EVENTS.has(event.type)) {
+      return c.json({ ok: true, ignored: event.type });
+    }
+
+    // Idempotency gate for handled types: Stripe retries on any non-2xx and
+    // can also re-deliver on network blips even after a 2xx. `stripe events
+    // resend` from the CLI also lands here. First-delivery only.
     const firstDelivery = deps.db.markEventProcessed(event.id, event.type);
     if (!firstDelivery) {
       return c.json({ ok: true, duplicate: true });
-    }
-
-    if (!HANDLED_EVENTS.has(event.type)) {
-      // Unknown event types must still return 2xx — otherwise Stripe keeps
-      // retrying for up to 3 days and the dashboard fills with failures.
-      return c.json({ ok: true, ignored: event.type });
     }
 
     try {
@@ -101,6 +117,7 @@ async function dispatch(event: Stripe.Event, db: Db): Promise<void> {
   switch (event.type) {
     case "payment_intent.succeeded":
     case "payment_intent.processing":
+    case "payment_intent.requires_action":
     case "payment_intent.canceled":
     case "payment_intent.payment_failed": {
       const pi = event.data.object as Stripe.PaymentIntent;
@@ -118,7 +135,9 @@ async function dispatch(event: Stripe.Event, db: Db): Promise<void> {
             ? "failed"
             : event.type === "payment_intent.canceled"
               ? "canceled"
-              : "processing";
+              : event.type === "payment_intent.requires_action"
+                ? "requires_action"
+                : "processing";
       db.updateOrderStatus(orderId, nextStatus);
       return;
     }

--- a/apps/web/src/routes/checkout/success.tsx
+++ b/apps/web/src/routes/checkout/success.tsx
@@ -1,8 +1,16 @@
+import { useMemo, useRef } from "react";
 import { createFileRoute, useSearch } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { TERMINAL_ORDER_STATUSES } from "@stripe-prototype/shared";
 import { getOrder } from "../../lib/api";
+
+// Stop polling after 2 minutes. If the webhook hasn't landed by then it's
+// either stuck upstream (Stripe side) or our handler threw after the
+// idempotency gate burned the event.id — in either case, further polling
+// won't help; the user needs to check the dashboard or server log.
+const MAX_POLL_MS = 120_000;
+const POLL_INTERVAL_MS = 2000;
 
 // Stripe appends its own redirect keys (payment_intent,
 // payment_intent_client_secret, redirect_status); we also ride along
@@ -28,11 +36,17 @@ export const Route = createFileRoute("/checkout/success")({
 function SuccessPage() {
   const search = useSearch({ from: "/checkout/success" });
   const orderId = search.order_id;
+  // `useMemo` runs once per mount (orderId doesn't change after validateSearch
+  // parses the URL), so startedAt anchors the elapsed-time measurement.
+  const startedAt = useMemo(() => Date.now(), []);
+  const timedOutRef = useRef(false);
 
-  // Poll the API until the order reaches a terminal status. The redirect
-  // lands before Stripe fires the webhook in test mode ~80% of the time, so
-  // the first fetch is usually still "processing". refetchInterval is a
-  // function so react-query stops polling automatically on terminal state.
+  // Poll the API until the order reaches a terminal status OR we've spent
+  // more than MAX_POLL_MS waiting. The redirect lands before Stripe fires
+  // the webhook in test mode ~80% of the time, so the first fetch is
+  // usually still "processing". refetchInterval is a function so react-query
+  // stops polling automatically on terminal state; the elapsed-ms check
+  // backstops the case where the webhook never lands.
   const order = useQuery({
     queryKey: ["order", orderId],
     queryFn: () => {
@@ -42,10 +56,18 @@ function SuccessPage() {
     enabled: !!orderId,
     refetchInterval: (query) => {
       const data = query.state.data;
-      if (!data) return 2000;
-      return TERMINAL_ORDER_STATUSES.has(data.status) ? false : 2000;
+      if (!data) return POLL_INTERVAL_MS;
+      if (TERMINAL_ORDER_STATUSES.has(data.status)) return false;
+      if (Date.now() - startedAt >= MAX_POLL_MS) {
+        timedOutRef.current = true;
+        return false;
+      }
+      return POLL_INTERVAL_MS;
     },
   });
+  const isNonTerminal =
+    !!order.data && !TERMINAL_ORDER_STATUSES.has(order.data.status);
+  const timedOut = timedOutRef.current && isNonTerminal;
 
   return (
     <div>
@@ -82,11 +104,17 @@ function SuccessPage() {
           {orderId && order.data && (
             <>
               <code>{order.data.status}</code>
-              {!TERMINAL_ORDER_STATUSES.has(order.data.status) && (
+              {isNonTerminal && !timedOut && (
                 <span style={{ color: "#666", fontSize: 12 }}>
                   {" "}
                   polling…
                 </span>
+              )}
+              {timedOut && (
+                <div style={{ color: "crimson", fontSize: 12, marginTop: 4 }}>
+                  webhook didn't land in 2 minutes — check the Stripe dashboard
+                  or server log
+                </div>
               )}
             </>
           )}

--- a/docs/audits/stage-3-audit.md
+++ b/docs/audits/stage-3-audit.md
@@ -1,0 +1,74 @@
+# Stage 3 Audit
+
+**Commits reviewed:** `d92f766` (API/DB), `69998b6` (webhook route), `fc749ba` (web + dev) on `stage/3-webhook-idempotency` (PR #15, merged as 09dca92).
+**Fixes branch:** `fix/stage-3-audit` — MAJORs applied post-merge per user direction (user merged #15 before the second reviewer returned).
+**Reviewed:** 2026-04-24
+**Reviewers:** `superpowers:code-reviewer` (full) + `codex:codex-rescue` (6 focused questions on 4 critical files)
+**Outcome:** 0 BLOCKER; 3 MAJORs fixed (2 codex-only, 1 code-reviewer-only), 2 MINORs fixed. Full reviewer dissent documented.
+
+## Consolidated findings
+
+### BLOCKER
+
+None.
+
+### MAJOR — fixed
+
+| # | Location | Finding | Fix applied |
+|---|---|---|---|
+| M1 | `webhooks.ts:42` | **Codex**: `c.req.raw.text()` bypasses Hono's body cache; Hono itself explicitly warns against consuming `req.raw`. If any middleware touches the body first, signature verification silently fails. **code-reviewer**: "correct, no middleware today" — but the fragility is real and a future middleware add breaks webhooks invisibly. | Switched to `await c.req.text()` — Hono's cached reader preserves the bytes Stripe signed and is robust to Hono-friendly middleware. Comment updated. |
+| M2 | `webhooks.ts:67,72` | **Codex MAJOR4**: idempotency gate ran BEFORE the HANDLED_EVENTS filter. Means unknown event types burn an event.id row; if a future stage adds a handler for that type, `stripe events resend` on the historic id silently no-ops. **code-reviewer N1**: argued the opposite — "keep as-is to prevent retroactive re-processing on deploy." Direct dissent. | Adopted codex. `stripe events resend` is an intentional backfill tool; the design should preserve the replay path, not block it. Filter moved BEFORE mark. Unknown events now 200 with no DB write. Comment explains the forward-compat reasoning. |
+| M3 | `webhooks.ts:15` HANDLED_EVENTS | **Codex**: `payment_intent.requires_action` is in the shared `OrderStatusSchema` but absent from webhook dispatch — 3DS/authenticating intents leave the DB stuck at `processing` while the user is being challenged. code-reviewer missed this. | Added `payment_intent.requires_action` to `HandledEvent` / `HANDLED_EVENTS` / dispatch. Maps to `"requires_action"` in `orders.status`. |
+| M4 | `packages/shared/src/index.ts:74` OrderStatusSchema | **code-reviewer**: `OrderStatusSchema` was missing `requires_capture`. Today unreachable via `automatic_payment_methods`, but `payments.ts` writes `intent.status` typed as `Stripe.PaymentIntent.Status` (which includes `requires_capture`). TS can't prove unreachability, and any future `capture_method: "manual"` PR would start 500-ing the GET /order endpoint silently. **codex 6**: "OK — 500 is right, but add `requires_capture` if manual capture is near-term." Soft agreement. | Added `requires_capture` to the enum. `db.ts:updateOrderStatus` tightened from `(status: string)` to `(status: OrderStatus)`, `insertOrder` likewise — the smuggling surface is now gone at compile time. |
+
+### MINOR — fixed on this branch
+
+| # | Location | Finding | Fix applied |
+|---|---|---|---|
+| m1 | `success.tsx` polling | **code-reviewer N2**: handler-error poisoning (documented at `webhooks.ts:82-88`) would leave orders stuck in `processing` with no backoff; the success-page poll spins forever. | Added `MAX_POLL_MS = 120_000` cap via `useMemo`/`useRef` elapsed-time check in `refetchInterval`. After 2 minutes non-terminal, poll stops and UI shows "webhook didn't land in 2 minutes — check the Stripe dashboard or server log". |
+| m2 | `api/index.ts:25` | **code-reviewer N5**: root `GET /` returned `stage: 1` — stale since Stage 1. | Bumped to `stage: 3`. |
+| m3 | `webhooks.ts:46` comment | **Codex 1**: "sync would fail under Bun" comment is too strong; Bun 1.2 has `node:crypto` shim and would likely work. constructEventAsync is still the correct choice for Web-Crypto-style runtimes, but the justification should be "preferred for Web Crypto portability", not "sync fails". | Comment rewritten. Default tolerance (300s) now passed explicitly for readability (codex suggestion). |
+| m4 | `stage-3-observations.md` | **code-reviewer M2**: `GET /order/:orderId` has no auth. Prototype scope, so acceptable today — but if this pattern gets paste-copied into the main app integration it's a real cross-account data-exposure bug. | Added a "Security note — DO NOT paste this into the real integration as-is" section with the three changes required (session-bind ownership, reject non-owner, don't return `paymentIntentId` to unauthorized callers). |
+
+### MINOR / NIT — filed as issues (deferred)
+
+- **stage-3/A** — UNIQUE index on `orders(payment_intent_id)`: `CREATE UNIQUE INDEX IF NOT EXISTS` fails fast on pre-existing duplicates (practically impossible in this repo's write path, but defensive). Codex suggested a one-shot pre-check that names the offending rows. Defer: no real migration story for a prototype.
+- **stage-3/B** — `updateOrderStatus` + handler dispatch are non-transactional. Known gap documented in `stage-3-observations.md`; the production fix is `db.transaction(() => { markEventProcessed(...); dispatch(...) })()`. Defer because the UI now has a 2-minute timeout that makes the observable failure visible.
+- **stage-3/C** — Raw-body UTF-8 vs bytes. `c.req.text()` always UTF-8 decodes; Stripe emits pure-ASCII JSON so it's byte-identical in practice. For belt-and-braces, `new Uint8Array(await c.req.raw.arrayBuffer())` + `constructEventAsync` would be provably bytes-exact. Codex didn't flag. Not worth the ceremony in a prototype.
+
+### NIT — not actioned
+
+- `webhooks.ts:15` HANDLED_EVENTS typed `ReadonlySet<string>` with a literal cast; `as const` on the array would be cleaner ergonomically.
+- `dispatch(event, db): Promise<void>` is synchronous today; the async return type keeps door open, not a bug.
+- `dev:webhooks` start-ordering race between api bind and `stripe listen` backlog replay — documented in observations, not code-fixed (would add `--delay` noise).
+
+## Reviewer convergence / disagreement
+
+| Finding | code-reviewer | codex | Resolution |
+|---|---|---|---|
+| Raw body (`c.req.raw.text()` vs `c.req.text()`) | "correct, no middleware" | **MAJOR: brittle, bypasses cache** | Adopted codex. Hono's internal warning is definitive; code-reviewer's observation was scoped to today's middleware. |
+| Idempotency ordering (mark-first vs filter-first) | **keep as-is (N1), prevents retroactive re-processing** | **MAJOR4: move filter BEFORE mark, preserves backfill path** | Adopted codex. `stripe events resend` is explicitly a backfill tool; blocking it was the wrong trade. |
+| `payment_intent.requires_action` dispatch | not flagged | **MAJOR** | Adopted codex. code-reviewer's scope was React semantics + direct bugs; this is a Stripe-contract gap. |
+| `requires_capture` in OrderStatusSchema | **MAJOR M1: add** | [OK] 6: 500 is right; add only if manual capture is near-term | Adopted code-reviewer. Cost is zero, future-proofing is real, and tightening `updateOrderStatus(status: OrderStatus)` only works if the enum covers the full PI status union. |
+| Signature-verify 400 status codes | OK | OK | Converged. |
+| Stablecoin-specific webhook types | not asked | [OK] — PI lifecycle is sufficient | Used as design confirmation; no change. |
+
+Reviewer coverage was complementary again — code-reviewer stronger on React/TanStack semantics (N2 polling cap), type-system gaps (M1 enum), and documentation drift (M5); codex stronger on Stripe/Hono SDK specifics (raw body, requires_action, SDK version verification, forward-compat idempotency).
+
+## Verification after fixes
+
+- `bun --filter '*' typecheck` exits 0 across all workspaces.
+- Runtime smoke: started api with `STRIPE_SECRET_KEY=sk_test_dummy STRIPE_WEBHOOK_SECRET=whsec_dummy`, confirmed `webhooks=on`; `curl` with missing signature → 400 `missing_signature`; `curl` with bogus signature → 400 `signature_mismatch`; `GET /api/payments/order/test` (nonexistent) → 404.
+- E2E with real sk_test_ + stripe listen not run (no test-mode session this cycle).
+
+### Manual test plan (addendum to `stage-3-observations.md`)
+
+Before merge of the fix PR, the user should run the 10-scenario checklist in `docs/notes/stage-3-observations.md` — in particular:
+
+1. **Idempotency ordering regression check.** `stripe trigger customer.created` (ignored type). Verify: `SELECT id FROM processed_events WHERE type='customer.created'` returns 0 rows. Previously it would have had 1.
+2. **requires_action path.** Use 3DS challenge card `4000 0025 0000 3155`. Observe `orders.status` reaches `requires_action` briefly before transitioning to `succeeded` after the challenge completes.
+3. **Polling cap.** Simulate a stuck webhook: stop `stripe listen` after the redirect lands but before the webhook forwards. Wait 2 minutes on `/checkout/success`. UI should show the timeout message.
+
+## Closed issues
+
+- #13 stage-2/B — `concurrently --kill-others-on-fail` instead of `-k` (landed in fc749ba on the Stage 3 merge).

--- a/docs/notes/stage-3-observations.md
+++ b/docs/notes/stage-3-observations.md
@@ -32,6 +32,22 @@ Stripe docs guarantee at-least-once delivery. The replay surface includes:
 
 **Known limitation for this prototype:** the insert is NOT in the same transaction as the handler's order-status update. A crash between `markEventProcessed` returning true and `updateOrderStatus` running would leave the event marked processed but the order un-transitioned — on next delivery the idempotency gate blocks the replay. Production would wrap both in `BEGIN IMMEDIATE; ... COMMIT` (bun:sqlite's `db.transaction(() => { ... })()` helper).
 
+**UI backstop for that failure mode:** `/checkout/success` caps polling at 2 minutes (`MAX_POLL_MS` in `apps/web/src/routes/checkout/success.tsx`). After the cap, the page shows "webhook didn't land in 2 minutes — check the Stripe dashboard or server log" instead of spinning forever.
+
+## Security note — DO NOT paste `GET /order/:orderId` into the real integration as-is
+
+`GET /api/payments/order/:orderId` is **unauthenticated** in this prototype. The orderId is a UUIDv4 (unguessable in practice), but the endpoint exposes `amount`, `currency`, `paymentIntentId`, `updatedAt`, and `status` — and anything fetching the URL will get a response. Today there is no real data and no auth model, which is fine for learning. Before pasting this into the main app:
+
+1. Bind order ownership to the session (customer_id or account_id from the logged-in user's cookie/JWT).
+2. Reject the request if the session's account doesn't own the orderId.
+3. Never return `paymentIntentId` to a caller that doesn't own the order — it's not secret in the Stripe sense, but leaking it makes cross-account correlation trivial.
+
+Flagged by code-reviewer in the Stage 3 audit (M2). Not fixed in the prototype because the scope is "test mode, no auth model"; captured here so the pattern doesn't get paste-copied into production.
+
+## Dev-script ordering note (observed)
+
+`concurrently --kill-others-on-fail` launches web / api / `stripe listen` in parallel. If `stripe listen` connects and Stripe dispatches a backlog event before the api binds 8787, the CLI logs a connection error for that one event and retries. No data loss — the retry succeeds once the api is up. If this gets annoying, add a small `--delay` on the stripe listen command or split into two scripts (start api, then start listen). Not worth fixing unless it recurs.
+
 ## Manual verification checklist
 
 1. **Setup**:

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -66,15 +66,24 @@ export type CreatePaymentIntentResponse = z.infer<
 
 // ---------- Stage 3: webhook-authoritative order status ----------
 
-// Authoritative per-order state. `succeeded|failed|refunded` are TERMINAL and
-// only set by webhook handlers. Everything else mirrors the PaymentIntent
-// status the create-or-reuse route wrote. The redirect_status query param on
-// /checkout/success is advisory — the source of truth is this enum, pulled
-// via GET /api/payments/order/:orderId after the webhook lands.
+// Authoritative per-order state. `succeeded|failed|refunded|canceled` are
+// TERMINAL. `succeeded|failed|refunded` are only set by webhook handlers;
+// everything else mirrors the PaymentIntent status the create-or-reuse route
+// wrote. The redirect_status query param on /checkout/success is advisory —
+// source of truth is this enum, pulled via GET /api/payments/order/:orderId
+// after the webhook lands.
+//
+// `requires_capture` is included for type-system closure: Stripe's
+// PaymentIntent.Status union includes it, and while today's create path uses
+// automatic capture (so the status is unreachable), the `insertOrder` path
+// would otherwise silently fail-cast on any future intent created with
+// capture_method: "manual". Keeps GET /order/:orderId from 500-ing in that
+// case.
 export const OrderStatusSchema = z.enum([
   "requires_payment_method",
   "requires_confirmation",
   "requires_action",
+  "requires_capture",
   "processing",
   "succeeded",
   "failed",


### PR DESCRIPTION
Post-merge fix PR for the Stage 3 dual audit. #15 was merged before codex-rescue returned its review; running both reviewers on the same code exposed three MAJORs that neither reviewer caught alone, plus one where the two disagreed outright. Full consolidation in `docs/audits/stage-3-audit.md`.

## MAJORs fixed

- **M1 (codex)** — `apps/api/src/routes/webhooks.ts:42`: `c.req.raw.text()` bypasses Hono's body cache and Hono's own source explicitly warns against it. Swapped for `await c.req.text()` (cached, robust against earlier Hono-helper middleware).
- **M2 (codex)** — `webhooks.ts`: idempotency gate moved BEFORE the HANDLED_EVENTS filter. Recording unknown events burned their replay path; `stripe events resend` after adding a new handler would silently no-op. code-reviewer argued the opposite (keep as-is); codex's reading prevailed because `events resend` is an intentional backfill tool.
- **M3 (codex)** — `webhooks.ts`: added `payment_intent.requires_action` to `HandledEvent` / `HANDLED_EVENTS` / dispatch. The shared `OrderStatusSchema` already reserved the slot; 3DS challenges were leaving orders stuck at `processing`.
- **M4 (code-reviewer)** — `packages/shared/src/index.ts`: added `requires_capture` to `OrderStatusSchema`. Unreachable today via `automatic_payment_methods`, but `payments.ts` writes `intent.status` typed as full `Stripe.PaymentIntent.Status`. Also tightened `db.updateOrderStatus(status: OrderStatus)` and `db.insertOrder` so smuggling unknown strings is impossible at compile time.

## MINORs fixed

- `/checkout/success` polling capped at 2 minutes (`MAX_POLL_MS` via `useMemo` + `useRef` elapsed-time check). After the cap the UI shows \"webhook didn't land in 2 minutes\" instead of spinning forever. Backstops the handler-error poisoning case documented in Stage 3 observations.
- `GET /` now returns `stage: 3` (was stale `stage: 1`).
- `webhooks.ts` comment softened per codex (\"sync would fail under Bun\" → \"preferred for Web Crypto portability\"); `constructEventAsync` default tolerance 300s now passed explicitly.
- `docs/notes/stage-3-observations.md` adds a \"Security note — DO NOT paste this into the real integration as-is\" section: `GET /order/:orderId` is unauthenticated, acceptable in prototype scope but the three required auth changes are documented so the pattern isn't paste-copied into production.

## Reviewer dissent (resolved)

| Topic | code-reviewer | codex | Resolution |
|---|---|---|---|
| Raw body | \"correct, no middleware today\" | **MAJOR: brittle, bypasses cache** | Codex |
| Idempotency ordering | keep as-is (prevent retroactive re-processing) | **MAJOR: filter-first (preserve backfill)** | Codex |
| `requires_capture` in enum | **MAJOR: add** | OK — add if manual capture near-term | code-reviewer |

## Verification

- `bun --filter '*' typecheck` exits 0 across all workspaces.
- Runtime smoke (sk_test_dummy + whsec_dummy, port 8788):
  - `GET /` → `{ok: true, stage: 3, api_version: \"2026-04-22.dahlia\"}`
  - `GET /api/payments/order/test` → 404
  - `POST /api/webhooks/stripe` with bogus signature → 400
  - Startup log: `webhooks=on`

## Test plan (before merge)

- [ ] `bun run dev:webhooks`, confirm api logs `stage=3 webhooks=on`
- [ ] **Idempotency ordering regression check**: `stripe trigger customer.created`; verify 0 rows in `processed_events` WHERE `type='customer.created'`. Under the old code there would have been 1.
- [ ] **requires_action path**: 3DS challenge card `4000 0025 0000 3155`; observe `orders.status` hits `requires_action` briefly before `succeeded`
- [ ] **Polling cap**: stop `stripe listen` after redirect lands but before webhook forwards; wait 2 min; UI shows timeout message
- [ ] All 10 scenarios in `docs/notes/stage-3-observations.md`

Deferred MINORs will be filed as issues (stage-3/A, /B, /C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)