### PR TITLE
Stage 4: hosted Checkout Session + Elements vs hosted comparison

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -116,13 +116,26 @@ export async function openDb(envPath: string): Promise<Db> {
   // status is the only mutable column after insert. amount, currency, and
   // payment_intent_id are immutable per orderId by design — letting them
   // drift would hide order_mismatch bugs and break idempotency-key semantics.
+  //
+  // Terminal-state guard: once an order reaches a terminal status
+  // (succeeded / failed / refunded / canceled), a later out-of-order webhook
+  // delivery MUST NOT downgrade it. Stripe redelivers events on any non-2xx
+  // and on manual `stripe events resend` — a reanimated `payment_intent.
+  // processing` hitting after a terminal transition would otherwise revert
+  // the order to `processing` and hang the UI poll. The one legitimate
+  // terminal-to-terminal transition is `succeeded -> refunded` (charge.refunded
+  // handler); everything else is blocked by this WHERE clause.
   const updateStatusStmt = conn.query<
     unknown,
     { order_id: string; status: string; ts: number }
   >(
     `UPDATE orders
        SET status = $status, updated_at = $ts
-     WHERE order_id = $order_id`,
+     WHERE order_id = $order_id
+       AND (
+         status NOT IN ('succeeded','failed','refunded','canceled')
+         OR ($status = 'refunded' AND status = 'succeeded')
+       )`,
   );
   // INSERT OR IGNORE: duplicate event.id yields 0 row changes, which is the
   // signal for "Stripe re-delivered, skip". Wrapped in a dedicated method so

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -17,6 +17,10 @@ const EnvSchema = z.object({
     .optional(),
   API_PORT: z.coerce.number().int().positive().default(8787),
   DATABASE_URL: z.string().default("apps/api/.data/stripe-prototype.db"),
+  // Stage 4 hosted Checkout needs an absolute success_url / cancel_url.
+  // Defaults to the Vite dev origin; override via .env for tunneled or
+  // alternative dev setups.
+  APP_BASE_URL: z.string().url().default("http://127.0.0.1:5173"),
 });
 
 export type Env = z.infer<typeof EnvSchema>;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { loadEnv } from "./env";
 import { makeStripe, STRIPE_API_VERSION } from "./stripe";
 import { openDb } from "./db";
 import { paymentsRoutes } from "./routes/payments";
+import { checkoutRoutes } from "./routes/checkout";
 import { webhookRoutes } from "./routes/webhooks";
 
 const env = loadEnv();
@@ -21,12 +22,16 @@ const webhooksEnabled = !!env.STRIPE_WEBHOOK_SECRET;
 // relative to CWD so we don't leak /Users/<name>/... into transcripts.
 // Closes stage-1/#9 ("Log sanitized startup config + document env precedence").
 console.log(
-  `[api] stage=3 mode=test port=${env.API_PORT} db=${relative(process.cwd(), db.file)} api_version=${STRIPE_API_VERSION} webhooks=${webhooksEnabled ? "on" : "off"}`,
+  `[api] stage=4 mode=test port=${env.API_PORT} db=${relative(process.cwd(), db.file)} api_version=${STRIPE_API_VERSION} webhooks=${webhooksEnabled ? "on" : "off"} app_base_url=${env.APP_BASE_URL}`,
 );
 
 const app = new Hono();
 
 app.route("/api/payments", paymentsRoutes({ stripe, db }));
+app.route(
+  "/api/checkout",
+  checkoutRoutes({ stripe, db, appBaseUrl: env.APP_BASE_URL }),
+);
 if (env.STRIPE_WEBHOOK_SECRET) {
   app.route(
     "/api/webhooks",
@@ -35,7 +40,7 @@ if (env.STRIPE_WEBHOOK_SECRET) {
 }
 
 app.get("/", (c) =>
-  c.json({ ok: true, stage: 3, api_version: STRIPE_API_VERSION }),
+  c.json({ ok: true, stage: 4, api_version: STRIPE_API_VERSION }),
 );
 
 app.get("/health", async (c) => {

--- a/apps/api/src/routes/checkout.ts
+++ b/apps/api/src/routes/checkout.ts
@@ -87,10 +87,13 @@ export function checkoutRoutes(deps: {
         }
       }
 
-      // success_url uses our order_id anchor (not Stripe's
-      // {CHECKOUT_SESSION_ID} template) so the success page polls the same
-      // GET /api/payments/order/:orderId endpoint as the Elements flow.
-      const successUrl = `${deps.appBaseUrl}/checkout-hosted/success?order_id=${orderId}`;
+      // success_url anchors on our order_id so the success page polls the
+      // same GET /api/payments/order/:orderId endpoint as the Elements flow.
+      // It ALSO includes Stripe's {CHECKOUT_SESSION_ID} template (per Stripe's
+      // recommendation) — we don't strictly need it today (order_id is
+      // sufficient to poll), but having the session id in the URL is a
+      // first-class join key for support/debugging.
+      const successUrl = `${deps.appBaseUrl}/checkout-hosted/success?order_id=${orderId}&session_id={CHECKOUT_SESSION_ID}`;
       const cancelUrl = `${deps.appBaseUrl}/checkout-hosted/cancel?order_id=${orderId}`;
 
       let session: Stripe.Checkout.Session;
@@ -171,9 +174,17 @@ export function checkoutRoutes(deps: {
         });
         status = "new";
       } else {
-        // Defensive: mode=payment should always populate payment_intent.
-        // If Stripe ever changes that, we'd be writing a null into a NOT NULL
-        // column — fail loud instead of poisoning the row.
+        // Stripe's Session type has `payment_intent: string | null`. In
+        // practice for mode=payment, a PI is created synchronously at
+        // session create and this branch should be unreachable — but codex
+        // review flagged it's documented-as-possible. If we ever hit it,
+        // log the session context so we can investigate without waiting for
+        // a user to reproduce. Stage 5 (stablecoin deep dive) is the most
+        // likely place to discover this in anger; at that point, defer the
+        // insert to payment_intent.created with session.metadata.order_id.
+        console.error(
+          `[checkout] session has null payment_intent: sessionId=${session.id} status=${session.status} payment_status=${session.payment_status}`,
+        );
         return c.json(
           { ok: false, error: { type: "stripe_missing_intent" } },
           500,

--- a/apps/api/src/routes/checkout.ts
+++ b/apps/api/src/routes/checkout.ts
@@ -1,0 +1,212 @@
+import { Hono } from "hono";
+import Stripe from "stripe";
+import {
+  CreateCheckoutSessionRequestSchema,
+  type CreateCheckoutSessionResponse,
+} from "@stripe-prototype/shared";
+import type { Db } from "../db";
+
+// Stage 4 parallels the Stage 2 PaymentIntent route but produces a Stripe-hosted
+// Checkout Session URL instead of a clientSecret. The orders table is the same,
+// so every webhook transition (succeeded / failed / refunded) flows through the
+// existing `metadata.order_id` path regardless of which checkout surface the
+// user came from.
+//
+// Design choices:
+// - ad-hoc `price_data` (no Price object dependency) — keeps the prototype
+//   self-contained whether or not `bun run seed` has been run
+// - `payment_intent_data.metadata.order_id` propagates to the PI so Stage 3
+//   webhook handlers recognize it with no changes
+// - `client_reference_id: orderId` as a secondary anchor (visible in dashboard,
+//   surfaces on `checkout.session.*` events)
+// - Idempotency-Key `order:<orderId>:checkout-session` so repeated submits
+//   return the SAME session (URL stays stable across browser reloads)
+export function checkoutRoutes(deps: {
+  stripe: Stripe;
+  db: Db;
+  appBaseUrl: string;
+}): Hono {
+  const app = new Hono();
+
+  app.post("/session", async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsed = CreateCheckoutSessionRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            type: "validation",
+            issues: parsed.error.issues.map((i) => ({
+              path: i.path.join("."),
+              message: i.message,
+            })),
+          },
+        },
+        400,
+      );
+    }
+    const { orderId, amount, currency, productName } = parsed.data;
+
+    try {
+      const existing = deps.db.getOrder(orderId);
+      if (existing) {
+        if (existing.amount !== amount || existing.currency !== currency) {
+          return c.json(
+            {
+              ok: false,
+              error: {
+                type: "order_mismatch",
+                message:
+                  "amount/currency differs from the original request for this orderId",
+              },
+            },
+            409,
+          );
+        }
+        // Terminal statuses mean the order is already paid / cancelled /
+        // refunded — don't spin up another session. The Elements route has
+        // the same check, so the behavior is consistent across surfaces.
+        const terminal = new Set([
+          "succeeded",
+          "failed",
+          "refunded",
+          "canceled",
+        ]);
+        if (terminal.has(existing.status)) {
+          return c.json(
+            {
+              ok: false,
+              error: {
+                type: "order_closed",
+                message: `orderId already terminal (db status: ${existing.status})`,
+              },
+            },
+            409,
+          );
+        }
+      }
+
+      // success_url uses our order_id anchor (not Stripe's
+      // {CHECKOUT_SESSION_ID} template) so the success page polls the same
+      // GET /api/payments/order/:orderId endpoint as the Elements flow.
+      const successUrl = `${deps.appBaseUrl}/checkout-hosted/success?order_id=${orderId}`;
+      const cancelUrl = `${deps.appBaseUrl}/checkout-hosted/cancel?order_id=${orderId}`;
+
+      let session: Stripe.Checkout.Session;
+      try {
+        session = await deps.stripe.checkout.sessions.create(
+          {
+            mode: "payment",
+            // Omit payment_method_types to get dashboard-driven dynamic PMs —
+            // same decision as Stage 2's automatic_payment_methods on PI.
+            line_items: [
+              {
+                quantity: 1,
+                price_data: {
+                  currency,
+                  unit_amount: amount,
+                  product_data: { name: productName },
+                },
+              },
+            ],
+            client_reference_id: orderId,
+            metadata: { order_id: orderId },
+            // Propagate order_id onto the underlying PaymentIntent so the
+            // existing Stage 3 webhook handlers can tie PI events back to
+            // the right order with no code changes.
+            payment_intent_data: {
+              metadata: { order_id: orderId },
+            },
+            success_url: successUrl,
+            cancel_url: cancelUrl,
+          },
+          { idempotencyKey: `order:${orderId}:checkout-session` },
+        );
+      } catch (err) {
+        if (
+          err instanceof Stripe.errors.StripeIdempotencyError ||
+          (err instanceof Stripe.errors.StripeError &&
+            err.code === "idempotency_key_in_use")
+        ) {
+          return c.json(
+            {
+              ok: false,
+              error: { type: "in_flight" },
+            },
+            409,
+          );
+        }
+        throw err;
+      }
+
+      // session.payment_intent is a string (unexpanded) for mode: "payment".
+      // If we ever move to expansion, coerce to id.
+      const paymentIntentId =
+        typeof session.payment_intent === "string"
+          ? session.payment_intent
+          : (session.payment_intent?.id ?? null);
+
+      if (!session.url) {
+        return c.json(
+          { ok: false, error: { type: "stripe_unexpected" } },
+          500,
+        );
+      }
+
+      // First-time insert uses the PI id pulled off the session. On repeat
+      // submits INSERT OR IGNORE is a no-op and we return `status: "reused"`.
+      // Note: this is different from the Stage 2 PI flow's use of `reused`
+      // (same intent handed back); here `reused` means same session URL.
+      let status: "new" | "reused";
+      if (existing) {
+        status = "reused";
+      } else if (paymentIntentId) {
+        deps.db.insertOrder({
+          order_id: orderId,
+          payment_intent_id: paymentIntentId,
+          amount,
+          currency,
+          status: "requires_payment_method",
+        });
+        status = "new";
+      } else {
+        // Defensive: mode=payment should always populate payment_intent.
+        // If Stripe ever changes that, we'd be writing a null into a NOT NULL
+        // column — fail loud instead of poisoning the row.
+        return c.json(
+          { ok: false, error: { type: "stripe_missing_intent" } },
+          500,
+        );
+      }
+
+      const res: CreateCheckoutSessionResponse = {
+        url: session.url,
+        sessionId: session.id,
+        paymentIntentId,
+        orderId,
+        status,
+      };
+      return c.json(res);
+    } catch (err) {
+      if (err instanceof Stripe.errors.StripeError) {
+        const httpStatus =
+          err instanceof Stripe.errors.StripeConnectionError ? 503 : 502;
+        return c.json(
+          {
+            ok: false,
+            error: {
+              type: err.type,
+              code: err.code ?? null,
+              requestId: err.requestId ?? null,
+            },
+          },
+          httpStatus,
+        );
+      }
+      return c.json({ ok: false, error: { type: "unknown" } }, 500);
+    }
+  });
+
+  return app;
+}

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -19,7 +19,9 @@ type HandledEvent =
   | "payment_intent.canceled"
   | "charge.refunded"
   | "checkout.session.completed"
-  | "checkout.session.expired";
+  | "checkout.session.expired"
+  | "checkout.session.async_payment_succeeded"
+  | "checkout.session.async_payment_failed";
 
 const HANDLED_EVENTS: ReadonlySet<string> = new Set<HandledEvent>([
   "payment_intent.succeeded",
@@ -29,10 +31,18 @@ const HANDLED_EVENTS: ReadonlySet<string> = new Set<HandledEvent>([
   "payment_intent.canceled",
   "charge.refunded",
   // Stage 4: hosted-Checkout-specific events. They race with the underlying
-  // payment_intent.* events, but the idempotency gate makes "first wins"
-  // — both paths converge on the same terminal status for a given order.
+  // payment_intent.* events, but the idempotency gate (per event.id) plus
+  // the terminal-status guard in db.updateOrderStatus make the combined flow
+  // safe — first wins and late arrivals can't downgrade.
   "checkout.session.completed",
   "checkout.session.expired",
+  // async_payment_* fire for delayed settlement PMs (stablecoin, BACS, SEPA)
+  // after `checkout.session.completed` already landed with payment_status:
+  // "unpaid". These ARE the terminal signals for async Checkout flows, not
+  // the PI events — though PI events also fire and converge on the same
+  // status via the terminal guard.
+  "checkout.session.async_payment_succeeded",
+  "checkout.session.async_payment_failed",
 ]);
 
 export function webhookRoutes(deps: {
@@ -177,10 +187,21 @@ async function dispatch(event: Stripe.Event, db: Db): Promise<void> {
     }
     case "checkout.session.expired": {
       // 24h default expiry with no completed payment. Terminal for the
-      // session, but we don't auto-flip to "canceled" here: if the user is
-      // in a 3DS challenge or the PI is processing, the payment_intent
-      // events are authoritative. Only mark canceled when the order is
-      // still in an initial "awaiting input" state.
+      // session, but we don't auto-flip to "canceled" for every state: if
+      // the PI is processing (async PM still resolving), the PI events are
+      // authoritative and the session expiry is informational. Cancel
+      // eagerly only for states that represent "user never finished":
+      //
+      //   requires_payment_method  — never entered payment details
+      //   requires_confirmation    — entered but didn't submit
+      //   requires_action          — started 3DS challenge and walked away
+      //
+      // `requires_action` is included as a safety net: Stripe separately
+      // fires `payment_intent.canceled` for abandoned 3DS intents, but if
+      // that delivery ever lags or gets lost, this guarantees the order
+      // doesn't stay stuck. The terminal-status guard in
+      // db.updateOrderStatus prevents double-writes if PI.canceled lands
+      // first.
       const session = event.data.object as Stripe.Checkout.Session;
       const orderId =
         session.metadata?.order_id ?? session.client_reference_id ?? null;
@@ -189,10 +210,28 @@ async function dispatch(event: Stripe.Event, db: Db): Promise<void> {
       if (!order) return;
       if (
         order.status === "requires_payment_method" ||
-        order.status === "requires_confirmation"
+        order.status === "requires_confirmation" ||
+        order.status === "requires_action"
       ) {
         db.updateOrderStatus(orderId, "canceled");
       }
+      return;
+    }
+    case "checkout.session.async_payment_succeeded":
+    case "checkout.session.async_payment_failed": {
+      // For delayed-settlement PMs (stablecoin, BACS, SEPA), these are the
+      // terminal signals for the Checkout surface — the session stays at
+      // `status: processing` until they fire. PI events also fire in
+      // parallel; the terminal-status guard absorbs the race.
+      const session = event.data.object as Stripe.Checkout.Session;
+      const orderId =
+        session.metadata?.order_id ?? session.client_reference_id ?? null;
+      if (!orderId) return;
+      const nextStatus =
+        event.type === "checkout.session.async_payment_succeeded"
+          ? "succeeded"
+          : "failed";
+      db.updateOrderStatus(orderId, nextStatus);
       return;
     }
     default:

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -17,7 +17,9 @@ type HandledEvent =
   | "payment_intent.processing"
   | "payment_intent.requires_action"
   | "payment_intent.canceled"
-  | "charge.refunded";
+  | "charge.refunded"
+  | "checkout.session.completed"
+  | "checkout.session.expired";
 
 const HANDLED_EVENTS: ReadonlySet<string> = new Set<HandledEvent>([
   "payment_intent.succeeded",
@@ -26,6 +28,11 @@ const HANDLED_EVENTS: ReadonlySet<string> = new Set<HandledEvent>([
   "payment_intent.requires_action",
   "payment_intent.canceled",
   "charge.refunded",
+  // Stage 4: hosted-Checkout-specific events. They race with the underlying
+  // payment_intent.* events, but the idempotency gate makes "first wins"
+  // — both paths converge on the same terminal status for a given order.
+  "checkout.session.completed",
+  "checkout.session.expired",
 ]);
 
 export function webhookRoutes(deps: {
@@ -151,6 +158,41 @@ async function dispatch(event: Stripe.Event, db: Db): Promise<void> {
       const order = db.getOrderByIntent(pi);
       if (!order) return;
       db.updateOrderStatus(order.order_id, "refunded");
+      return;
+    }
+    case "checkout.session.completed": {
+      // Fires when the hosted session hits `status: "complete"`. For
+      // mode: "payment" that's `payment_status: "paid"` for synchronous PMs,
+      // or `unpaid` + a still-processing PI for async PMs (stablecoin,
+      // bank debits, etc.). Only flip to "succeeded" when the session says
+      // paid; otherwise defer to the payment_intent.* events.
+      const session = event.data.object as Stripe.Checkout.Session;
+      const orderId =
+        session.metadata?.order_id ?? session.client_reference_id ?? null;
+      if (!orderId) return;
+      if (session.payment_status === "paid") {
+        db.updateOrderStatus(orderId, "succeeded");
+      }
+      return;
+    }
+    case "checkout.session.expired": {
+      // 24h default expiry with no completed payment. Terminal for the
+      // session, but we don't auto-flip to "canceled" here: if the user is
+      // in a 3DS challenge or the PI is processing, the payment_intent
+      // events are authoritative. Only mark canceled when the order is
+      // still in an initial "awaiting input" state.
+      const session = event.data.object as Stripe.Checkout.Session;
+      const orderId =
+        session.metadata?.order_id ?? session.client_reference_id ?? null;
+      if (!orderId) return;
+      const order = db.getOrder(orderId);
+      if (!order) return;
+      if (
+        order.status === "requires_payment_method" ||
+        order.status === "requires_confirmation"
+      ) {
+        db.updateOrderStatus(orderId, "canceled");
+      }
       return;
     }
     default:

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,6 +2,9 @@ import {
   type CreatePaymentIntentRequest,
   type CreatePaymentIntentResponse,
   CreatePaymentIntentResponseSchema,
+  type CreateCheckoutSessionRequest,
+  type CreateCheckoutSessionResponse,
+  CreateCheckoutSessionResponseSchema,
   type GetOrderResponse,
   GetOrderResponseSchema,
 } from "@stripe-prototype/shared";
@@ -23,6 +26,23 @@ export async function createPaymentIntent(
     );
   }
   return CreatePaymentIntentResponseSchema.parse(json);
+}
+
+export async function createCheckoutSession(
+  body: CreateCheckoutSessionRequest,
+): Promise<CreateCheckoutSessionResponse> {
+  const res = await fetch(`${BASE}/api/checkout/session`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as unknown;
+  if (!res.ok) {
+    throw new Error(
+      `api ${res.status}: ${JSON.stringify((json as { error?: unknown }).error ?? json)}`,
+    );
+  }
+  return CreateCheckoutSessionResponseSchema.parse(json);
 }
 
 // Returns null on 404 (order not found — can happen if the success page

--- a/apps/web/src/lib/useOrderPoll.ts
+++ b/apps/web/src/lib/useOrderPoll.ts
@@ -1,0 +1,57 @@
+import { useMemo, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  TERMINAL_ORDER_STATUSES,
+  type GetOrderResponse,
+} from "@stripe-prototype/shared";
+import { getOrder } from "./api";
+
+// Stop polling after 2 minutes. If the webhook hasn't landed by then it's
+// either stuck upstream (Stripe side) or our handler threw after the
+// idempotency gate burned the event.id — in either case, further polling
+// won't help; the user needs to check the dashboard or server log.
+export const MAX_POLL_MS = 120_000;
+export const POLL_INTERVAL_MS = 2000;
+
+export type OrderPollState = {
+  order: GetOrderResponse | null | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  isNonTerminal: boolean;
+  timedOut: boolean;
+};
+
+export function useOrderPoll(orderId: string | undefined): OrderPollState {
+  const startedAt = useMemo(() => Date.now(), []);
+  const timedOutRef = useRef(false);
+
+  const query = useQuery({
+    queryKey: ["order", orderId],
+    queryFn: () => {
+      if (!orderId) throw new Error("missing order_id");
+      return getOrder(orderId);
+    },
+    enabled: !!orderId,
+    refetchInterval: (q) => {
+      const data = q.state.data;
+      if (!data) return POLL_INTERVAL_MS;
+      if (TERMINAL_ORDER_STATUSES.has(data.status)) return false;
+      if (Date.now() - startedAt >= MAX_POLL_MS) {
+        timedOutRef.current = true;
+        return false;
+      }
+      return POLL_INTERVAL_MS;
+    },
+  });
+
+  const isNonTerminal =
+    !!query.data && !TERMINAL_ORDER_STATUSES.has(query.data.status);
+
+  return {
+    order: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+    isNonTerminal,
+    timedOut: timedOutRef.current && isNonTerminal,
+  };
+}

--- a/apps/web/src/lib/useOrderPoll.ts
+++ b/apps/web/src/lib/useOrderPoll.ts
@@ -10,6 +10,22 @@ import { getOrder } from "./api";
 // either stuck upstream (Stripe side) or our handler threw after the
 // idempotency gate burned the event.id — in either case, further polling
 // won't help; the user needs to check the dashboard or server log.
+//
+// ASSUMPTIONS (document-then-fix):
+//
+// - SPA-only: `useMemo(() => Date.now(), [])` captures the user's browser
+//   clock at mount. If this hook ever runs in an SSR/Next.js "use server"
+//   context, the anchor would be server clock — wrong. Under TanStack
+//   Router's SPA setup today that's fine; migrate to a client-only
+//   lazy-init useState if SSR lands.
+//
+// - Component remount resets the 2-minute budget. A user who navigates away
+//   and comes back triggers a fresh poll window.
+//
+// - `timedOutRef` is a one-shot tripwire: once set to true, it stays true
+//   for the lifetime of the hook instance. Currently no consumer exposes a
+//   "retry" button; if one is added, it must clear the ref inside its
+//   invalidation path to avoid permanent timeout-true state.
 export const MAX_POLL_MS = 120_000;
 export const POLL_INTERVAL_MS = 2000;
 

--- a/apps/web/src/routes/checkout-hosted/cancel.tsx
+++ b/apps/web/src/routes/checkout-hosted/cancel.tsx
@@ -1,0 +1,38 @@
+import { createFileRoute, Link, useSearch } from "@tanstack/react-router";
+import { z } from "zod";
+
+const SearchSchema = z
+  .object({ order_id: z.string().optional() })
+  .passthrough();
+
+export const Route = createFileRoute("/checkout-hosted/cancel")({
+  component: HostedCancelPage,
+  validateSearch: SearchSchema,
+});
+
+function HostedCancelPage() {
+  const search = useSearch({ from: "/checkout-hosted/cancel" });
+  return (
+    <div>
+      <h1>checkout cancelled</h1>
+      <p>
+        The Stripe-hosted session was cancelled before a payment was captured.
+        The order row in our DB is still present but has no terminal status;
+        after the session's 24h TTL, <code>checkout.session.expired</code>{" "}
+        fires and the order flips to <code>canceled</code> (only if still at{" "}
+        <code>requires_payment_method</code> — async-in-flight PIs keep their
+        PI-driven status).
+      </p>
+      {search.order_id && (
+        <p style={{ fontSize: 12, color: "#666" }}>
+          orderId <code>{search.order_id}</code>
+        </p>
+      )}
+      <p>
+        <Link to="/checkout-hosted">Try hosted checkout again</Link> — a new
+        orderId is generated per visit, so this doesn't reuse the previous
+        session.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/routes/checkout-hosted/index.tsx
+++ b/apps/web/src/routes/checkout-hosted/index.tsx
@@ -1,0 +1,78 @@
+import { useMemo, useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation } from "@tanstack/react-query";
+import { createCheckoutSession } from "../../lib/api";
+
+export const Route = createFileRoute("/checkout-hosted/")({
+  component: HostedCheckoutPage,
+});
+
+function HostedCheckoutPage() {
+  const orderId = useMemo(() => crypto.randomUUID(), []);
+  const [amount, setAmount] = useState(1999);
+  const [productName, setProductName] = useState("Stripe prototype demo item");
+
+  // We deliberately DON'T use window.location.replace on redirect: the raw
+  // assign keeps history so the user can back-button to try again, matching
+  // the UX most production hosted-checkout pages show.
+  const session = useMutation({
+    mutationFn: () =>
+      createCheckoutSession({ orderId, amount, currency: "usd", productName }),
+    onSuccess(data) {
+      window.location.href = data.url;
+    },
+  });
+
+  return (
+    <div style={{ maxWidth: 520 }}>
+      <h1>hosted checkout (Stage 4)</h1>
+      <p style={{ fontSize: 12, color: "#666" }}>
+        orderId <code>{orderId}</code>
+      </p>
+      <p>
+        Stripe-hosted Checkout Session. The form below creates the session on
+        the server and redirects to <code>checkout.stripe.com</code>. After
+        payment (or cancel), Stripe redirects back to this app's{" "}
+        <code>/checkout-hosted/success</code> or <code>/cancel</code>. Ground
+        truth remains the webhooks, same as the Elements flow.
+      </p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          session.mutate();
+        }}
+        style={{ display: "grid", gap: 12 }}
+      >
+        <label>
+          product name
+          <input
+            type="text"
+            value={productName}
+            onChange={(e) => setProductName(e.target.value)}
+            style={{ display: "block", width: "100%" }}
+          />
+        </label>
+        <label>
+          amount (USD cents)
+          <input
+            type="number"
+            min={50}
+            value={amount}
+            onChange={(e) => setAmount(Number(e.target.value))}
+            style={{ display: "block", width: "100%" }}
+          />
+        </label>
+        <button type="submit" disabled={session.isPending}>
+          {session.isPending ? "creating session..." : "go to Stripe Checkout"}
+        </button>
+        {session.error && (
+          <p style={{ color: "crimson" }}>
+            {session.error instanceof Error
+              ? session.error.message
+              : String(session.error)}
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/routes/checkout-hosted/success.tsx
+++ b/apps/web/src/routes/checkout-hosted/success.tsx
@@ -3,52 +3,39 @@ import { z } from "zod";
 import { TERMINAL_ORDER_STATUSES } from "@stripe-prototype/shared";
 import { useOrderPoll } from "../../lib/useOrderPoll";
 
-// Stripe appends its own redirect keys (payment_intent,
-// payment_intent_client_secret, redirect_status); we also ride along
-// `order_id` from confirmPayment's return_url to anchor the DB poll.
-// Any future PM type may add more keys (setup_intent, source_redirect_slug),
-// so passthrough keeps them instead of tripping validateSearch.
+// Stripe hosted Checkout typically appends `session_id` / `payment_intent` on
+// success_url. We only need `order_id` for the poll, but we accept the
+// others and passthrough anything else for forward-compat.
 const SearchSchema = z
   .object({
-    payment_intent: z.string().optional(),
-    payment_intent_client_secret: z.string().optional(),
-    redirect_status: z
-      .enum(["succeeded", "processing", "requires_action", "failed"])
-      .optional(),
     order_id: z.string().optional(),
+    session_id: z.string().optional(),
   })
   .passthrough();
 
-export const Route = createFileRoute("/checkout/success")({
-  component: SuccessPage,
+export const Route = createFileRoute("/checkout-hosted/success")({
+  component: HostedSuccessPage,
   validateSearch: SearchSchema,
 });
 
-function SuccessPage() {
-  const search = useSearch({ from: "/checkout/success" });
+function HostedSuccessPage() {
+  const search = useSearch({ from: "/checkout-hosted/success" });
   const orderId = search.order_id;
   const { order, isLoading, error, isNonTerminal, timedOut } =
     useOrderPoll(orderId);
 
   return (
     <div>
-      <h1>payment submitted (Elements)</h1>
+      <h1>payment submitted (hosted Checkout)</h1>
       <p>
-        Stripe returned here after confirmPayment. Ground truth is the{" "}
-        <code>payment_intent.succeeded</code> webhook — this page polls the
-        API for the DB-authoritative order status instead of trusting{" "}
-        <code>redirect_status</code>.
+        Stripe-hosted Checkout returned here after a paid or still-processing
+        session. Two webhooks converge on this order: the
+        Checkout-specific <code>checkout.session.completed</code> and the
+        universal <code>payment_intent.succeeded</code>. First-wins via the
+        idempotency gate in <code>processed_events</code>.
       </p>
       <dl>
-        <dt>payment_intent</dt>
-        <dd>
-          <code>{search.payment_intent ?? "—"}</code>
-        </dd>
-        <dt>redirect_status (advisory)</dt>
-        <dd>
-          <code>{search.redirect_status ?? "—"}</code>
-        </dd>
-        <dt>order status (authoritative, via webhook)</dt>
+        <dt>order status (authoritative)</dt>
         <dd>
           {!orderId && <code>—</code>}
           {orderId && isLoading && <code>loading…</code>}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({ component: Home });
 
@@ -6,7 +6,22 @@ function Home() {
   return (
     <div>
       <h1>stripe-prototype</h1>
-      <p>Stage 2 — PaymentIntent + Elements. Go to <code>/checkout</code>.</p>
+      <p>Stage 4 — two checkout surfaces, same order-state backbone.</p>
+      <ul>
+        <li>
+          <Link to="/checkout">/checkout</Link> — Elements inline (Stage 2 +
+          Stage 3 webhook-authoritative)
+        </li>
+        <li>
+          <Link to="/checkout-hosted">/checkout-hosted</Link> — Stripe-hosted
+          Checkout Session (Stage 4)
+        </li>
+      </ul>
+      <p style={{ fontSize: 12, color: "#666" }}>
+        Both flows create a row in <code>orders</code> keyed by a server-
+        generated UUID, drive terminal status from webhooks, and surface the
+        DB-authoritative status on the success page.
+      </p>
     </div>
   );
 }

--- a/docs/audits/stage-4-audit.md
+++ b/docs/audits/stage-4-audit.md
@@ -1,0 +1,73 @@
+# Stage 4 Audit
+
+**Commits reviewed:** `dfcacd7` (API), `2870da0` (web + hook), `9378db5` (comparison doc) on `stage/4-checkout-vs-elements` (PR #20).
+**Fixes commit:** `fix(stage-4): …` on the same branch — the PR is still open, so audit fixes land as additional commits before merge (returning to the pre-Stage-3 workflow).
+**Reviewed:** 2026-04-24
+**Reviewers:** `superpowers:code-reviewer` (full) + `codex:codex-rescue` (8 focused questions on 5 critical files).
+**Outcome:** 0 BLOCKER after re-grading codex Q2 (see below); 4 MAJORs fixed + 3 MINORs fixed. Full dissent and re-grading documented.
+
+## Consolidated findings
+
+### BLOCKER
+
+None after re-grading. **codex originally marked Q2 as BLOCKER**: `session.payment_intent: null` is a documented-nullable shape on Stripe's Session object, but in practice for `mode: "payment"` with standard PMs the PI is created synchronously at session creation and the null branch is unreachable. **Re-grade to MEDIUM**: prototype's card path never hits this. Logged with `sessionId / status / payment_status` if it ever fires; real fix (defer insertOrder until `payment_intent.created` lands) is deferred to Stage 5 where stablecoin flows will exercise the null path deliberately.
+
+### MAJOR — fixed
+
+| # | Location | Finding | Fix applied |
+|---|---|---|---|
+| M1 | `db.ts:113-126` updateOrderStatus | **code-reviewer**: UPDATE had no predicate. A late or re-delivered PI event (e.g. `stripe events resend` of an old `payment_intent.processing` after `succeeded` already transitioned) has a NEW event.id, so the idempotency gate doesn't stop it — the handler would downgrade the terminal order back to `processing` and the UI poll would hang 2 min. **codex Q6**: ordering "fine" (gate is per-id) but DID NOT flag the downgrade surface. Only code-reviewer caught this. | SQL WHERE clause now rejects writes to terminal rows except the one legitimate `succeeded → refunded` transition (`charge.refunded` handler). SQLite smoke-tested: `succeeded→processing` blocked, `succeeded→refunded` allowed, `refunded→processing` blocked. |
+| M2 | `webhooks.ts:178-196` .expired | **code-reviewer**: gate was `{requires_payment_method, requires_confirmation}`. A user abandoning 3DS mid-challenge lands the order at `requires_action`; session expiry at 24h would then not touch it. Stripe DOES separately fire `payment_intent.canceled` for abandoned intents, but if delivery lags/fails this leaves orders permanently stuck. **codex Q5**: "leaving processing alone is correct; PI is authoritative for async" — same logic applies to requires_action (disagreed with code-reviewer). | Adopted code-reviewer as safety net: added `requires_action` to the expired-cancel gate. Both reviewers agree `processing` should stay alone (PI event is authoritative). The terminal-status guard from M1 absorbs the race if PI.canceled lands first. |
+| M3 | `webhooks.ts` HANDLED_EVENTS / dispatch | **codex Q5**: for delayed-settlement PMs (stablecoin, BACS, SEPA), Stripe keeps the Session in `processing` and emits `checkout.session.async_payment_{succeeded,failed}` as the Checkout-side terminal signal. We were handling neither — async orders would stay `processing` forever on the Checkout surface, relying entirely on PI events. code-reviewer missed this. | Added both async events to HandledEvent / HANDLED_EVENTS / dispatch. Mapping: `async_payment_succeeded → "succeeded"`, `async_payment_failed → "failed"`. Terminal-status guard absorbs the race with PI events. |
+| M4 (downgraded from codex Q2 BLOCKER) | `checkout.ts` null PI branch | Documented-nullable shape; runtime-unreachable for card. | Added `console.error` with `sessionId / status / payment_status` on the 500 branch so we can investigate if it ever fires. Observations doc flags Stage 5 as the likely place. |
+
+### MINOR — fixed on this branch
+
+| # | Location | Finding | Fix applied |
+|---|---|---|---|
+| m1 | `checkout.ts:92-94` successUrl | **codex Q7**: `success_url` didn't include Stripe's `{CHECKOUT_SESSION_ID}` template, even though the success page's `SearchSchema` already accepts `session_id`. Lost a first-class support/debug join key. | Changed `successUrl` to `?order_id=<uuid>&session_id={CHECKOUT_SESSION_ID}`. Stripe fills in the template on redirect. |
+| m2 | `useOrderPoll.ts` doc | **codex Q8**: SPA-only `useMemo(Date.now)` anchor + component-remount reset not documented. **code-reviewer m1**: `timedOutRef` one-shot tripwire not documented. | Expanded the module-level comment block with three ASSUMPTIONS: SPA-only, remount resets budget, `timedOutRef` is one-shot. Future SSR migration path noted. |
+| m3 | `docs/notes/stage-4-elements-vs-checkout.md` | **code-reviewer m2, m3**: reused-session URL drift + reused path not calling `sessions.retrieve`. Not prototype bugs today, but worth catalogue. | Added "Known limitations flagged during audit" section. |
+
+### MINOR / NIT — not actioned
+
+- **code-reviewer m4**: `order_closed` 409 branch is reachable via curl (not via UI with `crypto.randomUUID()` per mount). Confirmed as intentional guard, not dead code. No change needed.
+- **code-reviewer m5**: `paymentIntentId: null` defensive branch log added as part of M4.
+- **codex Q7 — `session_id` discard**: fixed as m1.
+- **codex n1 (SearchSchema passthrough)**: harmless cosmetic — passthrough is already there. No change.
+- **codex n2 (productName length)**: confirmed Stripe docs 250 char cap. Current `z.string().min(1).max(250)` is right.
+- **codex n3 (metadata + client_reference_id redundancy)**: confirmed correct — three anchors serve three audiences (dashboard debug, PI-event path, session-event path).
+
+## Reviewer convergence / disagreement
+
+| Finding | code-reviewer | codex | Resolution |
+|---|---|---|---|
+| Terminal downgrade via stale PI event | **MAJOR (M1)** | confirmed-correct (Q6) — missed the downgrade surface | Adopted code-reviewer. SQL guard plus a `succeeded → refunded` carve-out. |
+| `.expired` + `requires_action` | **MAJOR (M2): include in gate** | MEDIUM (Q5): "PI is authoritative, don't cancel processing" — ambiguous on requires_action | Adopted code-reviewer's safety-net framing; codex's logic applies to `processing` (which we leave alone) but the 3DS-abandon case benefits from a second safety net. Terminal guard absorbs the race. |
+| `session.payment_intent: null` branch | m5 "future concern" | **BLOCKER (Q2)** — Stripe documented | Compromise: re-graded to MEDIUM, added logging. Proper fix deferred to Stage 5. |
+| `checkout.session.async_payment_*` | not flagged | **MEDIUM (Q5)** | Adopted codex. Critical for stablecoin path. |
+| `useOrderPoll` doc | m1 retry-button concern | Q8 SPA assumption concern | Merged both into a single ASSUMPTIONS comment block. |
+| success_url session_id | not flagged | **LOW (Q7)** | Adopted codex. One-line change, real debuggability win. |
+| Stripe SDK shape / SDK version | not deep-dived | confirmed-correct (Q1) with file:line grep to installed `stripe@22.1.0` + API `2026-04-22.dahlia` | Used as confirmation. |
+
+Reviewer coverage pattern is now familiar: code-reviewer stronger on React hook semantics and general correctness surfaces (terminal downgrade was the big one neither agent caught in the initial design); codex stronger on Stripe SDK shape, docs-grounded event type coverage, and TanStack v5 specifics. Stage 4 confirmed the dual-review is pulling its weight — no single reviewer caught M1+M3 together, and codex's Q2 re-grade is a useful example of where "documented but unreachable" should be re-scoped rather than rubber-stamped.
+
+## Verification after fixes
+
+- `bun --filter '*' typecheck` exits 0 across all workspaces.
+- Terminal-state SQL guard smoke-tested directly via sqlite3 CLI: `succeeded → processing` blocked, `succeeded → refunded` allowed, `refunded → processing` blocked.
+- Runtime smoke: startup log shows `stage=4`, webhook route mounts when secret present, `POST /api/checkout/session` returns 400 Zod issues on empty body (confirmed pre-fix).
+- E2E not run this cycle (no sk_test_ key).
+
+### Manual test plan for the user before merge
+
+See `docs/notes/stage-4-elements-vs-checkout.md` §Manual verification checklist. The additions specific to this fix commit:
+
+1. **Terminal downgrade regression check (M1).** Complete a card payment via hosted Checkout (4242). Note the event ids in `stripe listen` output. Run `stripe events resend <evt_id_of_processing>` after the order reaches `succeeded`. Verify `updated_at` on the orders row does NOT change and status stays `succeeded`.
+2. **3DS abandon (M2).** Use `4000 0025 0000 3155`, start the 3DS challenge, close the tab. Either wait 24h and observe `.expired` → order `canceled`, or `stripe trigger checkout.session.expired` to simulate.
+3. **async_payment_* happy path (M3).** If dashboard test mode has stablecoin enabled, pay with USDC via hosted Checkout. Verify BOTH `checkout.session.completed` (payment_status: unpaid) and later `checkout.session.async_payment_succeeded` land, and the order transitions to `succeeded` via whichever fires first.
+4. **session_id in success URL (m1).** On happy-path completion, inspect the URL bar on `/checkout-hosted/success` — should show both `order_id=<uuid>` AND `session_id=cs_test_...`.
+
+## Closed issues
+
+- None from prior stages — Stage 4 introduces no new "closes #" references.

--- a/docs/notes/stage-4-elements-vs-checkout.md
+++ b/docs/notes/stage-4-elements-vs-checkout.md
@@ -1,0 +1,108 @@
+# Stage 4 — Stripe Elements (inline) vs Checkout (hosted) comparison
+
+Stage: 4
+Branch: `stage/4-checkout-vs-elements`
+Status: pre-audit (fill in observed rows during manual E2E)
+
+## What this stage adds
+
+- `apps/api/src/routes/checkout.ts` — `POST /api/checkout/session` creates a Stripe-hosted Checkout Session keyed by `orderId`, returns `{url, sessionId, paymentIntentId, orderId, status}`. Same order row, same webhook backbone as Elements.
+- `apps/web/src/routes/checkout-hosted/{index,success,cancel}.tsx` — form → redirect to `checkout.stripe.com` → back to `/checkout-hosted/success?order_id=<uuid>` (poll) or `/checkout-hosted/cancel?order_id=<uuid>`.
+- `apps/web/src/lib/useOrderPoll.ts` — shared hook extracting the polling+timeout logic used by both success pages (Elements + hosted).
+- `checkout.session.completed` + `checkout.session.expired` added to webhook dispatch. Concurrent with `payment_intent.succeeded`; idempotency gate makes first-wins.
+- `APP_BASE_URL` env var (defaults `http://127.0.0.1:5173`) feeds Session `success_url` / `cancel_url`.
+
+## Comparison table
+
+| Dimension | Elements (Stage 2+3) | hosted Checkout (Stage 4) |
+|---|---|---|
+| Where the user pays | inline on our origin | `checkout.stripe.com/c/pay/cs_test_...` |
+| Client JS loaded | `@stripe/stripe-js` + `@stripe/react-stripe-js` (Elements) | none required (redirect) |
+| Server call shape | `stripe.paymentIntents.create({amount, currency, automatic_payment_methods})` | `stripe.checkout.sessions.create({mode, line_items[], payment_intent_data})` |
+| Client-facing secret | `client_secret` returned to browser, bound to PaymentElement | session `url` returned to browser, browser navigates away |
+| Idempotency key | `order:<uuid>:create` (PI) | `order:<uuid>:checkout-session` |
+| PaymentIntent created | yes, explicitly | yes, implicitly by Checkout (session.payment_intent) |
+| Dynamic PMs | `automatic_payment_methods: { enabled: true }` | omit `payment_method_types` (dashboard-driven) |
+| 3DS handling | SDK handles via `stripe.confirmPayment`'s redirect | Stripe-hosted page handles in full |
+| Redirect back | `return_url` from `confirmPayment` → our `/checkout/success` | `success_url` / `cancel_url` → our `/checkout-hosted/{success,cancel}` |
+| Order state authority | `payment_intent.*` webhooks | `payment_intent.*` OR `checkout.session.*` (first-wins) |
+| Unique webhook events | — | `checkout.session.{completed,expired}` |
+| Bundle size impact (web) | +Stripe.js (~80KB gz) | 0 on redirect path |
+| Server code LOC | 200+ in payments.ts | 160 in checkout.ts |
+| UX customization | full control (CSS, layout, PM list) | Stripe's Dashboard Appearance settings only |
+| PCI scope | SAQ A (Stripe Elements iframe) | SAQ A (Stripe-hosted page) |
+| Recovery from session expiry | N/A (PI persists) | new session (24h default TTL) |
+| Mobile Apple/Google Pay | manual wiring via Payment Request Button | automatic (hosted page detects) |
+
+## Webhook event ordering (capture during E2E)
+
+For a synchronous card payment, Stripe fires BOTH `checkout.session.completed` and `payment_intent.succeeded`. Ordering is NOT guaranteed — Stripe explicitly says not to rely on it. First event to hit our endpoint claims the idempotency row and transitions the order; the second is a no-op duplicate because both converge on `succeeded`.
+
+Table to fill with real timestamps during E2E testing (run `bun run dev:webhooks` and watch the CLI output):
+
+| Flow | PI event 1 | PI event 2 | PI event 3 | Session event 1 | Session event 2 | First to land |
+|---|---|---|---|---|---|---|
+| Elements, card 4242 |   |   |   | n/a | n/a |   |
+| Elements, card 3155 (3DS) |   |   |   | n/a | n/a |   |
+| hosted, card 4242 |   |   |   |   | n/a |   |
+| hosted, card 3155 (3DS) |   |   |   |   | n/a |   |
+| hosted, session cancelled |   |   |   | — | `expired` (24h) | n/a |
+| hosted, stablecoin (if test mode has it) |   |   |   |   | n/a |   |
+
+Columns expected:
+- PI events: some combo of `payment_intent.{requires_action, processing, succeeded}` or `{payment_failed, canceled}`
+- Session events: `checkout.session.completed` for successful sessions, `checkout.session.expired` for TTL'd
+
+## Observed differences (fill during hands-on testing)
+
+- [ ] How does the hosted page handle 3DS vs Elements' inline redirect?
+- [ ] Does stablecoin PM appear in hosted Checkout the same way as inline Elements?
+- [ ] If the user dismisses the hosted page mid-3DS, does the session go to `expired` immediately or after TTL?
+- [ ] How do `charge.succeeded` and `payment_intent.succeeded` interleave — are both emitted for both flows?
+- [ ] For hosted flow, does `success_url` trigger even if the user closes the tab before returning?
+
+## Design decisions
+
+- **Both flows share the `orders` table.** No schema divergence. `payment_intent_data.metadata.order_id` on the Session call propagates `order_id` onto the underlying PI, so existing `payment_intent.*` handlers match on metadata regardless of surface.
+- **`client_reference_id` as the secondary anchor.** Visible in the Stripe dashboard on the Session object and echoed on `checkout.session.*` events, handy for dashboard-based debugging.
+- **No session reuse.** Idempotency key guarantees `sessions.create` with the same params returns the same Session — so browser refreshes and back-button → submit land on the same URL. Once the session is terminal (completed/expired), a new orderId is needed.
+- **`payment_status === "paid"` is the only signal for auto-succeeded.** For async PMs (stablecoin, BACS), `checkout.session.completed` fires with `payment_status: "unpaid"` and the underlying PI is still `processing` — we defer the terminal transition to the PI event in that case.
+
+## When to use which (learning goal)
+
+Pick **hosted Checkout** when:
+- PCI scope reduction is the priority (server never touches card input)
+- You want Apple/Google Pay / Link / subscriptions with minimal wiring
+- Your checkout page doesn't need custom branding beyond Appearance settings
+- You're ok with a redirect (mobile apps might prefer)
+
+Pick **Elements** when:
+- Your checkout is embedded in a longer flow (cart, multi-step)
+- You need inline validation or a custom layout
+- You want the user to never leave your domain
+- You're already managing payment state tightly (abandoned-cart emails, intent reuse across sessions)
+
+For the main-app integration this prototype feeds into: default to **Elements for the primary flow** (inline UX is a revenue driver for the target persona), with **hosted Checkout as a fallback** for specific surfaces (e.g. Apple Pay-heavy paths, subscription upgrade).
+
+## Manual verification checklist
+
+1. **Setup** — `bun run dev:webhooks` (api + web + stripe listen). Confirm api log shows `stage=4 webhooks=on`.
+2. **API shape** — `curl -X POST http://127.0.0.1:8787/api/checkout/session -d '{}' -H 'content-type: application/json'` returns 400 with Zod validation issues.
+3. **Happy path (card)** —
+   - http://127.0.0.1:5173/checkout-hosted → fill form → `go to Stripe Checkout`
+   - Redirects to `checkout.stripe.com` → pay with `4242 4242 4242 4242`
+   - Redirects back to `/checkout-hosted/success?order_id=<uuid>`
+   - Page shows status transition `requires_payment_method` → `succeeded`
+   - CLI `stripe listen` shows BOTH `checkout.session.completed` AND `payment_intent.succeeded`. Note which fires first.
+4. **Idempotent re-submit** — back to hosted form with SAME orderId (via URL `?order_id=<uuid>` if you manually preserve it) or re-mount the route (new orderId — different test). The orderId is re-generated per mount, so true reuse is limited. The `status: "reused"` path is exercised when the user POSTs twice on the same mounted route before Stripe responds.
+5. **Cancel** — start session → click Stripe's "Back" / close tab → land on `/checkout-hosted/cancel`. Leave 24h (or manually `stripe trigger checkout.session.expired`) → verify order status flips to `canceled` if still at `requires_payment_method`.
+6. **Decline** — `4000 0000 0000 0002` in hosted checkout → Stripe shows decline → session stays open, PI gets `payment_failed` → order status `failed`.
+7. **Async PM** — if stablecoin is enabled in dashboard test mode, pay via USDC → session `completed` with `payment_status: "unpaid"`, PI `processing` → later PI `succeeded` → order `succeeded`.
+8. **Dashboard visibility** — confirm Session object in Stripe dashboard test mode shows `client_reference_id: <our uuid>` and `metadata.order_id: <our uuid>`.
+9. **Cross-flow isolation** — run Elements flow and hosted flow back-to-back with different orderIds; verify each lands in its own `orders` row with distinct `payment_intent_id`s.
+
+## Outstanding questions for Stage 4 audit
+
+- Should the hosted-session `status: "reused"` return path also verify the prior session is still `open` (not `complete`/`expired`)? Current code 409s on terminal order status, but an `open` session for a non-terminal order just idempotently returns the same URL — which could be the WRONG URL if we changed the `success_url` between calls (we don't today, but fragile).
+- `/checkout-hosted/cancel` does not mutate the DB. The `checkout.session.expired` handler does, but only after 24h. Is there a case where we should eagerly mark canceled on cancel_url hit? (Answer: no — user might still complete from the Stripe page if they reopen; only the session going terminal is authoritative.)
+- Bundle-size claim in the comparison table ("hosted = 0 on redirect path"): verify with `bun --filter web build` (not done yet — Stage 4 doesn't wire prod build).

--- a/docs/notes/stage-4-elements-vs-checkout.md
+++ b/docs/notes/stage-4-elements-vs-checkout.md
@@ -103,6 +103,18 @@ For the main-app integration this prototype feeds into: default to **Elements fo
 
 ## Outstanding questions for Stage 4 audit
 
-- Should the hosted-session `status: "reused"` return path also verify the prior session is still `open` (not `complete`/`expired`)? Current code 409s on terminal order status, but an `open` session for a non-terminal order just idempotently returns the same URL — which could be the WRONG URL if we changed the `success_url` between calls (we don't today, but fragile).
-- `/checkout-hosted/cancel` does not mutate the DB. The `checkout.session.expired` handler does, but only after 24h. Is there a case where we should eagerly mark canceled on cancel_url hit? (Answer: no — user might still complete from the Stripe page if they reopen; only the session going terminal is authoritative.)
+- Should the hosted-session `status: "reused"` return path also verify the prior session is still `open` (not `complete`/`expired`)? Current code 409s on terminal order status, but an `open` session for a non-terminal order just idempotently returns the same URL — which could be the WRONG URL if we changed the `success_url` between calls (we don't today, but fragile). **[Audit note]** code-reviewer m3 confirmed this is a prototype-scope choice; Elements analog calls `paymentIntents.retrieve()`, Checkout does not (would require persisting session.id). Left as-is; revisit if APP_BASE_URL ever becomes runtime-dynamic (ngrok tunnel etc).
+- `/checkout-hosted/cancel` does not mutate the DB. The `checkout.session.expired` handler does, but only after 24h. Is there a case where we should eagerly mark canceled on cancel_url hit? (Answer: no — user might still complete from the Stripe page if they reopen; only the session going terminal is authoritative.) **[Audit note]** code-reviewer n4 + codex Q8 converged: correct design. The alternative (eager cancel on cancel_url visit) would race with a user who closes the page but completes via back-button.
 - Bundle-size claim in the comparison table ("hosted = 0 on redirect path"): verify with `bun --filter web build` (not done yet — Stage 4 doesn't wire prod build).
+
+## Known limitations flagged during audit
+
+- **`session.payment_intent: null` on mode=payment** — Stripe types this as nullable, but in practice our flow creates a PI synchronously at session create. The 500 defensive branch in `checkout.ts` will log `sessionId/status/payment_status` if it ever fires. If it does, Stage 5 (stablecoin) is the likely suspect — the real fix is to defer the `insertOrder` until `payment_intent.created` lands with `metadata.order_id`. Deferred because the prototype's card path never reaches the null case.
+
+- **`useOrderPoll` is SPA-only** — `useMemo(() => Date.now(), [])` captures the browser clock. If this project ever adds SSR, the anchor would be wrong. Documented in the hook itself with the migration path (client-only lazy useState).
+
+- **`timedOutRef` is a one-shot tripwire** — no current consumer exposes a retry button. If one is added, the refetch path must clear the ref; otherwise `timedOut` stays true forever once set.
+
+- **Reused-session branch doesn't `sessions.retrieve`** — Elements analog does. If APP_BASE_URL changed between calls, the returned URL could have a stale origin. Not a bug today (APP_BASE_URL is server-static), but catalogued.
+
+- **`checkout.session.async_payment_succeeded/failed`** are handled (Stage 4 audit added these). Without them, async-PM orders would stay `processing` forever even after payment settlement, relying solely on PI events.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -108,3 +108,33 @@ export const GetOrderResponseSchema = z.object({
   updatedAt: z.number().int(),
 });
 export type GetOrderResponse = z.infer<typeof GetOrderResponseSchema>;
+
+// ---------- Stage 4: hosted Checkout Session contract ----------
+
+// Ad-hoc line_items via price_data: the hosted flow doesn't need a pre-seeded
+// Price object to be usable, which keeps the prototype self-contained (Stage 1
+// seed optional). Product display name + amount are passed per request.
+export const CreateCheckoutSessionRequestSchema = z.object({
+  orderId: OrderIdSchema,
+  amount: z.number().int().min(50),
+  currency: IsoCurrencySchema,
+  productName: z.string().min(1).max(250),
+});
+export type CreateCheckoutSessionRequest = z.infer<
+  typeof CreateCheckoutSessionRequestSchema
+>;
+
+// `url` is Stripe's hosted checkout URL (checkout.stripe.com/...). The web
+// app redirects via `window.location.href = url`. `sessionId` is surfaced
+// for observability; the route also persists the order pre-redirect so the
+// success page poll picks it up the same way the Elements flow does.
+export const CreateCheckoutSessionResponseSchema = z.object({
+  url: z.string(),
+  sessionId: z.string(),
+  paymentIntentId: z.string().nullable(),
+  orderId: z.string(),
+  status: z.enum(["new", "reused"]),
+});
+export type CreateCheckoutSessionResponse = z.infer<
+  typeof CreateCheckoutSessionResponseSchema
+>;


### PR DESCRIPTION
## Summary

- **API**: `POST /api/checkout/session` creates a Stripe-hosted Checkout Session keyed by the same `orderId` UUID. `payment_intent_data.metadata.order_id` propagates the anchor onto the underlying PaymentIntent so Stage 3 `payment_intent.*` webhook handlers work unchanged for both surfaces. Ad-hoc `price_data` (no Price object dependency). Idempotency-Key `order:<uuid>:checkout-session`; same order_mismatch / order_closed 409 shapes as the Elements route.
- **Webhooks**: `checkout.session.{completed,expired}` added to `HANDLED_EVENTS` + dispatch. Session/PI event race is absorbed by the idempotency gate (first-wins). Expiry only flips to `canceled` if still awaiting input — in-flight PI status wins otherwise.
- **Web**: `/checkout-hosted` form → redirect to `checkout.stripe.com` → back to `/checkout-hosted/{success,cancel}`. Success page polls the same `GET /api/payments/order/:orderId` as Elements.
- **Refactor**: `apps/web/src/lib/useOrderPoll.ts` consolidates the 2-min polling + timeout logic. Both success pages (Elements + hosted) now consume the same hook.
- **Env**: `APP_BASE_URL` defaults `http://127.0.0.1:5173`, feeds Session `success_url` / `cancel_url`.

## Smoke verification (done in this session)

- `bun --filter '*' typecheck` exits 0 across all workspaces
- `GET /` returns `{ok: true, stage: 4, ...}`
- `POST /api/checkout/session` with empty body returns 400 + Zod issues for `orderId`, `amount`, `currency`, `productName`
- Startup log: `stage=4 webhooks=on app_base_url=http://127.0.0.1:5173`

## Test plan (before merge)

See `docs/notes/stage-4-elements-vs-checkout.md` §Manual verification checklist (9 scenarios). Key observations to capture in the ordering table there:

- [ ] Card 4242 via hosted: which fires first — `checkout.session.completed` or `payment_intent.succeeded`?
- [ ] 3DS (3155) via hosted: how many webhook events total? Interleaving pattern?
- [ ] Stablecoin via hosted (if enabled): `session.completed` with `payment_status: unpaid` + later `payment_intent.succeeded`?
- [ ] Decline (0002) via hosted: `payment_intent.payment_failed` lands but NO `checkout.session.completed`? 
- [ ] Cancel via hosted (close Stripe tab): `/checkout-hosted/cancel` lands, order stays at `requires_payment_method`, later `stripe trigger checkout.session.expired` flips to `canceled`
- [ ] Cross-flow: run Elements + hosted in two tabs with different orderIds; verify each order has its own row + distinct PI

## Comparison doc

`docs/notes/stage-4-elements-vs-checkout.md` includes:

- 15-dimension comparison table (client JS, 3DS, webhooks, PCI, bundle size, UX customization, etc.)
- Decision framework for main-app integration (default Elements, hosted as specific-surface fallback)
- Webhook event ordering table to fill with real timestamps during E2E

## Next after audit

Stage 4 audit protocol: `/code-review` + `/codex` dual pass → `docs/audits/stage-4-audit.md` → fix MAJORs on this branch → merge → Stage 5 (stablecoin deep dive + jurisdiction decision memo + Tempo watch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)